### PR TITLE
[ivp_collision] Deferred mindist delete flag should be reset after delete performed

### DIFF
--- a/ivp_intern/ivp_impact.cxx
+++ b/ivp_intern/ivp_impact.cxx
@@ -1241,6 +1241,7 @@ void IVP_Mindist::do_impact(){
 		// BUGBUG: someone changed a collision filter and didn't tell us!
 		IVP_ASSERT(0);
 		delete this;
+		g_fDeferDeleteMindist = false;
 		return;
 	}
 


### PR DESCRIPTION
This broke the entire physics engine for an entire session if for example `CBaseEntity::CollisionRulesChanged` is not called properly

https://developer.valvesoftware.com/wiki/Physics_Mayhem