### PR TITLE
[all] Improve Linux support

### DIFF
--- a/havana/havok/hk_base/base_types.h
+++ b/havana/havok/hk_base/base_types.h
@@ -5,7 +5,9 @@
 #include <signal.h>
 #endif
 
+#ifndef _LINUX
 #include <DirectXMath.h>
+#endif
 
 // dimhotepus: Use SSE when DirectXMath uses SSE.
 #ifdef _XM_SSE_INTRINSICS_
@@ -132,7 +134,7 @@ using hk_id = hk_uint32;
 #endif
 #define HK_TEMPLATE_INLINE inline
 
-#if defined(__i386__) || defined(WIN32)
+#if (defined(__i386__) || defined(WIN32)) && !defined(IVP_NO_PERFORMANCE_TIMER)
 #	define HK_HAVE_QUERY_PERFORMANCE_TIMER
 #endif
 

--- a/havana/havok/hk_base/hash/hash.h
+++ b/havana/havok/hk_base/hash/hash.h
@@ -11,7 +11,7 @@ class hk_Hash
 	public:
 
 		HK_TEMPLATE_INLINE hk_Hash(int size, hk_Memory *mem = hk_Memory::get_instance());
-			//: assert(size = 2,4,8,16,32 ... 2**x)
+			//: HK_ASSERT(size = 2,4,8,16,32 ... 2**x)
 		inline ~hk_Hash();
 
 		HK_TEMPLATE_INLINE void add_element( KV &key_value );

--- a/havana/havok/hk_base/hash/hash.inl
+++ b/havana/havok/hk_base/hash/hash.inl
@@ -92,7 +92,7 @@ KV* hk_Hash<KV>::search_element( KV &kv )
 
 template<class KV>
 hk_Hash<KV>::hk_Hash(int size, hk_Memory *mem)
-		//: assert(size = 2,4,8,16,32 ... 2**x)
+		//: HK_ASSERT(size = 2,4,8,16,32 ... 2**x)
 {
 	HK_ASSERT( size >= 1 );
 

--- a/havana/havok/hk_base/memory/memory.inl
+++ b/havana/havok/hk_base/memory/memory.inl
@@ -6,19 +6,11 @@
 
 inline void* hk_Memory::memcpy(void* dest, const void* src, hk_size_t size)
 {
-#ifdef _WIN32
 	return ::memcpy(dest,src,size);
-#else
-	return memcpy(dest,src,size);
-#endif
 }
 
 inline void* hk_Memory::memset(void* dest, hk_uchar val, hk_size_t size)
 {
-#ifdef _WIN32
 	return ::memset(dest, val, size);
-#else
-	return memset(dest, val, size);
-#endif
 }
 

--- a/havana/havok/hk_base/stopwatch/stopwatch_qpt.inl
+++ b/havana/havok/hk_base/stopwatch/stopwatch_qpt.inl
@@ -13,49 +13,69 @@
 #	error HK_HAVE_QUERY_PERFORMANCE_TIMER is defined, but no implementation.
 #endif
 
-inline hk_uint64 hk_query_performance_timer_start()
+inline hk_uint64 hk_query_cpu_timer_value(hk_uint32 &cpu_id)
 {
-	return __rdtsc();
+	// See https://www.felixcloutier.com/x86/rdtscp
+	// 
+	// The RDTSCP instruction is not a serializing instruction, but it does wait
+	// until all previous instructions have executed and all previous loads are
+	// globally visible.  But it does not wait for previous stores to be
+	// globally visible, and subsequent instructions may begin execution before
+	// the read operation is performed.  The following items may guide software
+	// seeking to order executions of RDTSCP:
+	// * If software requires RDTSCP to be executed only after all previous
+	// stores are globally visible, it can execute MFENCE immediately before
+	// RDTSCP.
+	// * If software requires RDTSCP to be executed prior to execution of any
+	// subsequent instruction (including any memory accesses), it can execute
+	// LFENCE immediately after RDTSCP.
+	_mm_mfence();
+	const hk_uint64 tsc{__rdtscp(&cpu_id)};
+	_mm_lfence();
+	return tsc;
 }
 
-inline hk_uint64 hk_query_performance_timer_stop()
-{
-	unsigned aux;
-	return __rdtscp(&aux);
-}
-
-inline void hk_query_performance_timer_frequency(hk_uint64* freq)
+inline hk_uint64 hk_query_cpu_current_frequency()
 {
 #ifdef _WIN32
 	LARGE_INTEGER waitTime, startCount, curCount;
+	hk_uint32 cpu_id_start, cpu_id_end;
 
 	// Take 1/128 of a second for the measurement.
 	QueryPerformanceFrequency( &waitTime );
-	unsigned scale = 7;
+	constexpr unsigned scale = 7;
 	waitTime.QuadPart >>= scale;
 
 	QueryPerformanceCounter( &startCount );
-	hk_uint64 startTicks = hk_query_performance_timer_start();
+	const hk_uint64 startTicks = hk_query_cpu_timer_value(cpu_id_start);
 	do
 	{
 		QueryPerformanceCounter( &curCount );
 	}
 	while ( curCount.QuadPart - startCount.QuadPart < waitTime.QuadPart );
-	hk_uint64 endTicks = hk_query_performance_timer_stop();
+	const hk_uint64 endTicks = hk_query_cpu_timer_value(cpu_id_end);
 
-	*freq = (endTicks - startTicks) << scale;
-	if ( *freq == 0 )
+	if (cpu_id_start != cpu_id_end)
+	{
+		// dimhotepus: Thread migrated to another CPU core, results are
+		// approximate.  Retry till thread executed on the same CPU core.
+		return hk_query_cpu_current_frequency();
+	}
+
+	hk_uint64 freq = (endTicks - startTicks) << scale;
+	if ( freq == 0 )
 	{
 		// Steam was seeing Divide-by-zero crashes on some Windows machines due to
 		// WIN64_AMD_DUALCORE_TIMER_WORKAROUND that can cause rdtsc to effectively
-		// stop. Staging doesn't have the workaround but I'm checking in the fix
-		// anyway. Return a plausible speed and get on with our day.
-		*freq = 2000000000U;
+		// stop.  Staging doesn't have the workaround but I'm checking in the fix
+		// anyway.  Return a plausible speed and get on with our day.
+		freq = 2000000000U;
 	}
 #else
 	// assume 2000 Mhz for now
-	*freq = 2000000000U;
+	freq = 2000000000U;
 #endif
+	return freq;
 }
 
 ////////////////////////
@@ -78,8 +98,9 @@ class hk_Stopwatch_qpt
 		hk_uint64	m_ticks_at_start;
 		hk_uint64	m_ticks_at_split;
 		hk_uint64	m_ticks_total;
-		bool		m_running_flag;
 		int			m_num_timings;
+		hk_uint32   m_core_id;
+		bool		m_running_flag;
 
 		static hk_uint64	s_ticks_per_second;
 };
@@ -87,7 +108,7 @@ class hk_Stopwatch_qpt
 inline hk_Stopwatch_qpt::hk_Stopwatch_qpt()
 {
 	if(s_ticks_per_second==0)
-		hk_query_performance_timer_frequency(&s_ticks_per_second);
+		s_ticks_per_second = hk_query_cpu_current_frequency();
 	reset();
 }
 
@@ -95,7 +116,7 @@ inline void hk_Stopwatch_qpt::start()
 {
 	HK_ASSERT(! m_running_flag);
 	m_running_flag = true;
-	m_ticks_at_start = hk_query_performance_timer_start();
+	m_ticks_at_start = hk_query_cpu_timer_value(m_core_id);
 	m_ticks_at_split = m_ticks_at_start;
 }
 
@@ -104,7 +125,7 @@ inline void hk_Stopwatch_qpt::stop()
 	HK_ASSERT(m_running_flag);
 
 	m_running_flag = false;
-	hk_uint64 ticks_now = hk_query_performance_timer_stop();
+	hk_uint64 ticks_now = hk_query_cpu_timer_value(m_core_id);
 	m_ticks_total += ticks_now - m_ticks_at_start;
 	++m_num_timings;
 }
@@ -114,8 +135,9 @@ inline void hk_Stopwatch_qpt::reset()
 	m_ticks_at_start = 0;
 	m_ticks_at_split = 0;
 	m_ticks_total = 0;
-	m_running_flag = false;
 	m_num_timings = 0;
+	m_core_id = 0;
+	m_running_flag = false;
 }
 
 inline hk_real hk_Stopwatch_qpt::get_elapsed_time() const
@@ -125,7 +147,7 @@ inline hk_real hk_Stopwatch_qpt::get_elapsed_time() const
 
 inline hk_real hk_Stopwatch_qpt::get_split_time()
 {
-	hk_uint64 ticks_now = hk_query_performance_timer_stop();
+	hk_uint64 ticks_now = hk_query_cpu_timer_value(m_core_id);
 	hk_uint64 sticks = ticks_now - m_ticks_at_split;
 	m_ticks_at_split = ticks_now;
 	return static_cast<hk_real>(sticks) / static_cast<hk_real>(s_ticks_per_second);

--- a/havana/havok/hk_math/base_math.h
+++ b/havana/havok/hk_math/base_math.h
@@ -56,6 +56,8 @@ class hk_Math
 		static bool almost_zero [[nodiscard]] ( hk_double a, hk_double eps = HK_DOUBLE_RES );
 };
 
+#ifndef IVP_NO_MATH_INL
 #include <hk_math/math.inl>
+#endif
 
 #endif /* HK_MATH_MATH_H */

--- a/havana/havok/hk_math/math.inl
+++ b/havana/havok/hk_math/math.inl
@@ -2,6 +2,10 @@
 #	include <hk_math/math_ps2.inl>
 #else	//HK_PS2
 
+#ifdef _LINUX
+#include <climits>
+#endif
+
 #include <algorithm>
 
 #ifdef _WIN32

--- a/havana/havok/hk_math/matrix3.h
+++ b/havana/havok/hk_math/matrix3.h
@@ -88,6 +88,7 @@ class hk_Matrix3
 
 		inline const hk_Vector3& get_column(int x) const;
 
+#ifndef _LINUX
 		// dimhotepus: Better DirectX math integration.
 		inline DirectX::XMFLOAT3X4A* XmBase()
 		{
@@ -101,6 +102,7 @@ class hk_Matrix3
 			static_assert(alignof(DirectX::XMFLOAT3X4A) == alignof(hk_Matrix3));
 			return reinterpret_cast<const DirectX::XMFLOAT3X4A*>(&m_elems);
 		}
+#endif
 
 	protected:
 

--- a/havana/havok/hk_math/odesolve.cpp
+++ b/havana/havok/hk_math/odesolve.cpp
@@ -145,7 +145,7 @@ void OdeRungaKutta4::ode_realloc(int new_size)
   k2 = new hk_real[state_size]; //-V121
   k3 = new hk_real[state_size]; //-V121
   k4 = new hk_real[state_size]; //-V121
-  assert(k1); assert(k2); assert(k3); assert(k4);
+  HK_ASSERT(k1); HK_ASSERT(k2); HK_ASSERT(k3); HK_ASSERT(k4);
 }
 
 

--- a/havana/havok/hk_math/transform.cpp
+++ b/havana/havok/hk_math/transform.cpp
@@ -35,7 +35,7 @@ void hk_Transform::set_identity_transform()
 void hk_Transform::get_4x4_column_major(hk_Transform* p) const
 {
 	static_assert( sizeof(*p) >= sizeof(hk_real) * 16 );
-	hkString::memcpy(p, &get_column(0), sizeof(*p));
+	::memcpy(p, &get_column(0), sizeof(*p));
 
 	reinterpret_cast<hk_real*>(p)[3]  = 0;
 	reinterpret_cast<hk_real*>(p)[7]  = 0;

--- a/havana/havok/hk_math/vector3/vector3.h
+++ b/havana/havok/hk_math/vector3/vector3.h
@@ -88,6 +88,7 @@ class hk_Vector3
 		inline       hk_real* get_real_pointer() { return &x; }
 		inline const hk_real* get_real_pointer() const { return &x; }
 
+#ifndef _LINUX
 		// dimhotepus: Better DirectX math integration.
 		inline DirectX::XMFLOAT4A* XmBase()
 		{
@@ -101,6 +102,7 @@ class hk_Vector3
 			static_assert(alignof(DirectX::XMFLOAT4A) == alignof(hk_Vector3));
 			return reinterpret_cast<const DirectX::XMFLOAT4A*>(&x);
 		}
+#endif
 
 	public:
 

--- a/havana/havok/hk_math/vector_fpu/vector_fpu.inl
+++ b/havana/havok/hk_math/vector_fpu/vector_fpu.inl
@@ -3,10 +3,10 @@
 inline void hk_VecFPU::fpu_add_multiple_row(hk_real *target_adress,hk_real *source_adress,hk_real factor,int size,hk_bool adress_aligned) {
     if(adress_aligned==HK_FALSE) {
 		//we have to calculate the block size and shift adresses to lower aligned adresses
-		intp result_adress = reinterpret_cast<intp>(source_adress) & hk_VecFPU_MEM_MASK_FLOAT;
+		hk_intp result_adress = reinterpret_cast<hk_intp>(source_adress) & hk_VecFPU_MEM_MASK_FLOAT;
 
-		target_adress = reinterpret_cast<hk_real*>( reinterpret_cast<intp>(target_adress) & hk_VecFPU_MEM_MASK_FLOAT);
-		size += (reinterpret_cast<intp>(source_adress)-result_adress)>>hk_VecFPU_MEMSHIFT_FLOAT;
+		target_adress = reinterpret_cast<hk_real*>( reinterpret_cast<hk_intp>(target_adress) & hk_VecFPU_MEM_MASK_FLOAT);
+		size += (reinterpret_cast<hk_intp>(source_adress)-result_adress)>>hk_VecFPU_MEMSHIFT_FLOAT;
 		source_adress=reinterpret_cast<hk_real*>(result_adress);
     }
 
@@ -60,9 +60,9 @@ inline void hk_VecFPU::fpu_add_multiple_row(hk_real *target_adress,hk_real *sour
 inline hk_real hk_VecFPU::fpu_large_dot_product(hk_real *base_a, hk_real *base_b, int size, hk_bool adress_aligned) {
     if(adress_aligned==HK_FALSE) {
 	    //we have to calculate the block size and shift adresses to lower aligned adresses
-	    intp result_adress = reinterpret_cast<intp>(base_a) & hk_VecFPU_MEM_MASK_FLOAT;
-	    base_b = reinterpret_cast<hk_real*>( reinterpret_cast<intp>(base_b) & hk_VecFPU_MEM_MASK_FLOAT);
-	    size += (reinterpret_cast<intp>(base_a)-result_adress)>>hk_VecFPU_MEMSHIFT_FLOAT;  // because start changed
+	    hk_intp result_adress = reinterpret_cast<hk_intp>(base_a) & hk_VecFPU_MEM_MASK_FLOAT;
+	    base_b = reinterpret_cast<hk_real*>( reinterpret_cast<hk_intp>(base_b) & hk_VecFPU_MEM_MASK_FLOAT);
+	    size += (reinterpret_cast<hk_intp>(base_a)-result_adress)>>hk_VecFPU_MEMSHIFT_FLOAT;  // because start changed
 	    base_a=reinterpret_cast<hk_real*>(result_adress);
     }
 
@@ -117,8 +117,8 @@ inline hk_real hk_VecFPU::fpu_large_dot_product(hk_real *base_a, hk_real *base_b
 inline void hk_VecFPU::fpu_multiply_row(hk_real *target_adress,hk_real factor,int size,hk_bool adress_aligned) {
     if(adress_aligned==HK_FALSE) {
 		//we have to calculate the block size and shift adresses to lower aligned adresses
-		intp adress,result_adress;
-		adress=reinterpret_cast<intp>(target_adress);
+		hk_intp adress,result_adress;
+		adress=reinterpret_cast<hk_intp>(target_adress);
 		result_adress=adress & hk_VecFPU_MEM_MASK_FLOAT;
 		size+=(adress-result_adress)>>hk_VecFPU_MEMSHIFT_FLOAT;
 		target_adress=reinterpret_cast<hk_real*>(result_adress);
@@ -164,11 +164,11 @@ inline void hk_VecFPU::fpu_multiply_row(hk_real *target_adress,hk_real factor,in
 inline void hk_VecFPU::fpu_exchange_rows(hk_real *target_adress1,hk_real *target_adress2,int size,hk_bool adress_aligned) {
     if(adress_aligned==HK_FALSE) {
 		//we have to calculate the block size and shift adresses to lower aligned adresses
-		intp adress=reinterpret_cast<intp>(target_adress1);
-		intp result_adress=adress & hk_VecFPU_MEM_MASK_FLOAT;
+		hk_intp adress=reinterpret_cast<hk_intp>(target_adress1);
+		hk_intp result_adress=adress & hk_VecFPU_MEM_MASK_FLOAT;
 		size+=(adress-result_adress)>>hk_VecFPU_MEMSHIFT_FLOAT;
 		target_adress1=reinterpret_cast<hk_real*>(result_adress);
-		adress=reinterpret_cast<intp>(target_adress2);
+		adress=reinterpret_cast<hk_intp>(target_adress2);
 		adress=adress & hk_VecFPU_MEM_MASK_FLOAT;
 		target_adress2=reinterpret_cast<hk_real*>(adress);
     }
@@ -207,11 +207,11 @@ inline void hk_VecFPU::fpu_exchange_rows(hk_real *target_adress1,hk_real *target
 inline void hk_VecFPU::fpu_copy_rows(hk_real *target_adress,hk_real *source_adress,int size,hk_bool adress_aligned) {
     if(adress_aligned==HK_FALSE) {
 		//we have to calculate the block size and shift adresses to lower aligned adresses
-		intp adress=reinterpret_cast<intp>(source_adress);
-		intp result_adress=adress & hk_VecFPU_MEM_MASK_FLOAT;
+		hk_intp adress=reinterpret_cast<hk_intp>(source_adress);
+		hk_intp result_adress=adress & hk_VecFPU_MEM_MASK_FLOAT;
 		size+=(adress-result_adress)>>hk_VecFPU_MEMSHIFT_FLOAT;
 		source_adress=reinterpret_cast<hk_real*>(result_adress);
-		adress=reinterpret_cast<intp>(target_adress);
+		adress=reinterpret_cast<hk_intp>(target_adress);
 		adress=adress & hk_VecFPU_MEM_MASK_FLOAT;
 		target_adress=reinterpret_cast<hk_real*>(adress);
     }
@@ -238,8 +238,8 @@ inline void hk_VecFPU::fpu_copy_rows(hk_real *target_adress,hk_real *source_adre
 
 inline void hk_VecFPU::fpu_set_row_to_zero(hk_real *target_adress,int size,hk_bool adress_aligned) {
     if(adress_aligned==HK_FALSE) {
-		intp adress=reinterpret_cast<intp>(target_adress);
-		intp result_adress=adress & hk_VecFPU_MEM_MASK_FLOAT;
+		hk_intp adress=reinterpret_cast<hk_intp>(target_adress);
+		hk_intp result_adress=adress & hk_VecFPU_MEM_MASK_FLOAT;
 		size+=(adress-result_adress)>>hk_VecFPU_MEMSHIFT_FLOAT;
 		target_adress=reinterpret_cast<hk_real*>(result_adress);
     }
@@ -274,9 +274,9 @@ inline int hk_VecFPU::calc_aligned_row_len(int unaligned_len, [[maybe_unused]] h
 inline void hk_VecFPU::fpu_add_multiple_row(hk_double *target_adress,hk_double *source_adress,hk_double factor,int size,hk_bool adress_aligned) {
     if(adress_aligned==HK_FALSE) {
 		//we have to calculate the block size and shift adresses to lower aligned adresses
-		intp result_adress = reinterpret_cast<intp>(source_adress) & hk_VecFPU_MEM_MASK_DOUBLE;
-		target_adress = (hk_double *)( reinterpret_cast<intp>(target_adress) & hk_VecFPU_MEM_MASK_DOUBLE);
-		size += (reinterpret_cast<intp>(source_adress)-result_adress)>>hk_VecFPU_MEMSHIFT_DOUBLE;
+		hk_intp result_adress = reinterpret_cast<hk_intp>(source_adress) & hk_VecFPU_MEM_MASK_DOUBLE;
+		target_adress = (hk_double *)( reinterpret_cast<hk_intp>(target_adress) & hk_VecFPU_MEM_MASK_DOUBLE);
+		size += (reinterpret_cast<hk_intp>(source_adress)-result_adress)>>hk_VecFPU_MEMSHIFT_DOUBLE;
 		source_adress=reinterpret_cast<hk_double*>(result_adress);
     }
 
@@ -330,9 +330,9 @@ inline void hk_VecFPU::fpu_add_multiple_row(hk_double *target_adress,hk_double *
 inline hk_double hk_VecFPU::fpu_large_dot_product(hk_double *base_a, hk_double *base_b, int size, hk_bool adress_aligned) {
     if(adress_aligned==HK_FALSE) {
 	    //we have to calculate the block size and shift adresses to lower aligned adresses
-	    intp result_adress = reinterpret_cast<intp>(base_a) & hk_VecFPU_MEM_MASK_DOUBLE;
-	    base_b = (hk_double *)( reinterpret_cast<intp>(base_b) & hk_VecFPU_MEM_MASK_DOUBLE);
-	    size += (reinterpret_cast<intp>(base_a)-result_adress)>>hk_VecFPU_MEMSHIFT_DOUBLE;  // because start changed
+	    hk_intp result_adress = reinterpret_cast<hk_intp>(base_a) & hk_VecFPU_MEM_MASK_DOUBLE;
+	    base_b = (hk_double *)( reinterpret_cast<hk_intp>(base_b) & hk_VecFPU_MEM_MASK_DOUBLE);
+	    size += (reinterpret_cast<hk_intp>(base_a)-result_adress)>>hk_VecFPU_MEMSHIFT_DOUBLE;  // because start changed
 	    base_a=reinterpret_cast<hk_double*>(result_adress);
     }
 
@@ -386,8 +386,8 @@ inline hk_double hk_VecFPU::fpu_large_dot_product(hk_double *base_a, hk_double *
 inline void hk_VecFPU::fpu_multiply_row(hk_double *target_adress,hk_double factor,int size,hk_bool adress_aligned) {
     if(adress_aligned==HK_FALSE) {
 		//we have to calculate the block size and shift adresses to lower aligned adresses
-		intp adress=reinterpret_cast<intp>(target_adress);
-		intp result_adress=adress & hk_VecFPU_MEM_MASK_DOUBLE;
+		hk_intp adress=reinterpret_cast<hk_intp>(target_adress);
+		hk_intp result_adress=adress & hk_VecFPU_MEM_MASK_DOUBLE;
 		size+=(adress-result_adress)>>hk_VecFPU_MEMSHIFT_DOUBLE;
 		target_adress=reinterpret_cast<hk_double*>(result_adress);
     }
@@ -431,11 +431,11 @@ inline void hk_VecFPU::fpu_multiply_row(hk_double *target_adress,hk_double facto
 inline void hk_VecFPU::fpu_exchange_rows(hk_double *target_adress1,hk_double *target_adress2,int size,hk_bool adress_aligned) {
     if(adress_aligned==HK_FALSE) {
 		//we have to calculate the block size and shift adresses to lower aligned adresses
-		intp adress=reinterpret_cast<intp>(target_adress1);
-		intp result_adress=adress & hk_VecFPU_MEM_MASK_DOUBLE;
+		hk_intp adress=reinterpret_cast<hk_intp>(target_adress1);
+		hk_intp result_adress=adress & hk_VecFPU_MEM_MASK_DOUBLE;
 		size+=(adress-result_adress)>>hk_VecFPU_MEMSHIFT_DOUBLE;
 		target_adress1=reinterpret_cast<hk_double*>(result_adress);
-		adress=reinterpret_cast<intp>(target_adress2);
+		adress=reinterpret_cast<hk_intp>(target_adress2);
 		adress=adress & hk_VecFPU_MEM_MASK_DOUBLE;
 		target_adress2=reinterpret_cast<hk_double *>(adress);
     }
@@ -476,11 +476,11 @@ inline void hk_VecFPU::fpu_exchange_rows(hk_double *target_adress1,hk_double *ta
 inline void hk_VecFPU::fpu_copy_rows(hk_double *target_adress,hk_double *source_adress,int size,hk_bool adress_aligned) {
     if(adress_aligned==HK_FALSE) {
 		//we have to calculate the block size and shift adresses to lower aligned adresses
-		intp adress=reinterpret_cast<intp>(source_adress);
-		intp result_adress=adress & hk_VecFPU_MEM_MASK_DOUBLE;
+		hk_intp adress=reinterpret_cast<hk_intp>(source_adress);
+		hk_intp result_adress=adress & hk_VecFPU_MEM_MASK_DOUBLE;
 		size+=(adress-result_adress)>>hk_VecFPU_MEMSHIFT_DOUBLE;
 		source_adress=reinterpret_cast<hk_double*>(result_adress);
-		adress=reinterpret_cast<intp>(target_adress);
+		adress=reinterpret_cast<hk_intp>(target_adress);
 		adress=adress & hk_VecFPU_MEM_MASK_DOUBLE;
 		target_adress=reinterpret_cast<hk_double *>(adress);
     }
@@ -508,8 +508,8 @@ inline void hk_VecFPU::fpu_copy_rows(hk_double *target_adress,hk_double *source_
 
 inline void hk_VecFPU::fpu_set_row_to_zero(hk_double *target_adress,int size,hk_bool adress_aligned) {
     if(adress_aligned==HK_FALSE) {
-		intp adress=reinterpret_cast<intp>(target_adress);
-		intp result_adress=adress & hk_VecFPU_MEM_MASK_DOUBLE;
+		hk_intp adress=reinterpret_cast<hk_intp>(target_adress);
+		hk_intp result_adress=adress & hk_VecFPU_MEM_MASK_DOUBLE;
 		size+=(adress-result_adress)>>hk_VecFPU_MEMSHIFT_DOUBLE;
 		target_adress=reinterpret_cast<hk_double*>(result_adress);
     }

--- a/havana/havok/hk_mopp/ivp_compact_mopp.hxx
+++ b/havana/havok/hk_mopp/ivp_compact_mopp.hxx
@@ -65,7 +65,7 @@ public:
      *****************************************************************************/
     const hkMoppCode* get_compact_ledge_tree_root() const 
 	{
-		char* base = (char*)(((intp)this) + this->offset_ledgetree_root);
+		char* base = (char*)(((hk_intp)this) + this->offset_ledgetree_root);
 		return((const hkMoppCode*)base);
     }
 

--- a/havana/havok/hk_physics/constraint/local_constraint_system/local_constraint_system.cpp
+++ b/havana/havok/hk_physics/constraint/local_constraint_system/local_constraint_system.cpp
@@ -261,7 +261,7 @@ void hk_Local_Constraint_System::apply_effector_PSI(hk_PSI_Info& pi, hk_Array<hk
 
 	//first do the setup
 	{
-		assert( max_constraints > m_constraints.length() );
+		HK_ASSERT( max_constraints > m_constraints.length() );
 
 		char* p_buffer = &buffer[0];
 		for (int i = 0; i < m_constraints.length(); i++) {

--- a/havana/havok/hk_physics/core/rigid_body_core.cpp
+++ b/havana/havok/hk_physics/core/rigid_body_core.cpp
@@ -49,7 +49,7 @@ void hk_Rigid_Body_Core::add_to_mass_matrix_inv(
 void hk_Rigid_Body_Core::apply_impulses( hk_Core_VMQ_Input &input,
 		const hk_real impulse_strength[])
 {
-	if ( physical_unmoveable || pinned || isnan(impulse_strength[0]) ) return;
+	if ( physical_unmoveable || pinned || std::isnan(impulse_strength[0]) ) return;
 	int i = input.m_n_queries-1;
 	hk_Impulse_Info *mq = input.m_vmq;
 	hk_Single_Rigid_Body_CFAD *ds = (hk_Single_Rigid_Body_CFAD *)input.m_buffer;

--- a/havana/havok/hk_physics/physics.h
+++ b/havana/havok/hk_physics/physics.h
@@ -228,6 +228,8 @@ public:
 	{
 		return m_environment;
 	}
+
+	virtual const char* get_controller_name() override { return "hk:link_ef"; };
 };
 class hk_Limited_Ball_Socket_BP *ivp_create_limited_ball_socket_bp(IVP_Template_Constraint *tmpl );
 class hk_Constraint *ivp_create_ragdoll_constraint_from_local_constraint_system(class hk_Local_Constraint_System *, IVP_Template_Constraint * );

--- a/ivp_collision/ivp_compact_ledge.hxx
+++ b/ivp_collision/ivp_compact_ledge.hxx
@@ -252,9 +252,9 @@ const IVP_Compact_Triangle *IVP_Compact_Edge::get_triangle() const
 {
     // mask 4 lowest adress bits to receive triangle
 #if defined(PLATFORM_64BITS)
-    return (IVP_Compact_Triangle *)(((uintp)this) & 0xfffffffffffffff0);
+    return (IVP_Compact_Triangle *)(((hk_uintp)this) & 0xfffffffffffffff0);
 #else
-    return (IVP_Compact_Triangle *)(((uintp)this) & 0xfffffff0);
+    return (IVP_Compact_Triangle *)(((hk_uintp)this) & 0xfffffff0);
 #endif
 }
 
@@ -277,30 +277,30 @@ const IVP_Compact_Poly_Point *IVP_Compact_Edge::get_start_point(const IVP_Compac
 
 const IVP_Compact_Edge *IVP_Compact_Edge::get_next() const
 {
-    int idx = (int)(((uintp)this) & 0x0c);
+    int idx = (int)(((hk_uintp)this) & 0x0c);
     return (IVP_Compact_Edge *)(((char *)this) + ((int *)(((char *)this->next_table)+idx))[0]);
 }
 
 int IVP_Compact_Edge::get_edge_index()const{
-  int idx = (int((((uintp)this) & 0x0c))>>2) - 1;
+  int idx = (int((((hk_uintp)this) & 0x0c))>>2) - 1;
     return idx;
 }
 
 IVP_Compact_Edge *IVP_Compact_Edge::get_next()
 {
-    int idx = (int)(((uintp)this) & 0x0c);
+    int idx = (int)(((hk_uintp)this) & 0x0c);
     return (IVP_Compact_Edge *)(((char *)this) + ((int *)(((char *)this->next_table)+idx))[0]);
 }
 
 const IVP_Compact_Edge *IVP_Compact_Edge::get_prev() const
 {
-    int idx = (int)(((uintp)this) & 0x0c);
+    int idx = (int)(((hk_uintp)this) & 0x0c);
     return (IVP_Compact_Edge *)(((char *)this) + ((int *)(((char *)this->prev_table)+idx))[0]);
 }
 
 IVP_Compact_Edge *IVP_Compact_Edge::get_prev() 
 {
-    int idx = (int)(((uintp)this) & 0x0c);
+    int idx = (int)(((hk_uintp)this) & 0x0c);
     return (IVP_Compact_Edge *)(((char *)this) + ((int *)(((char *)this->prev_table)+idx))[0]);
 }
 

--- a/ivp_collision/ivp_compact_ledge_solver.cxx
+++ b/ivp_collision/ivp_compact_ledge_solver.cxx
@@ -124,7 +124,7 @@ void IVP_Compact_Ledge_Solver::get_all_ledges( const IVP_Compact_Mopp* mopp, IVP
 
 	do
 	{
-		IVP_ASSERT(((uintp)(ledge) & 0xf) == 0);
+		IVP_ASSERT(((hk_uintp)(ledge) & 0xf) == 0);
 
 		all_ledges_out->add((IVP_Compact_Ledge*)ledge);
 
@@ -698,16 +698,16 @@ IVP_BOOL IVP_Compact_Ledge_Solver::check_ledge(const IVP_Compact_Ledge *cl)
     // For debugging only
     // Checks for consistency
 
-	IVP_ASSERT ( (intp(cl) & 15) == 0);
+	IVP_ASSERT ( (hk_intp(cl) & 15) == 0);
 	const IVP_Compact_Poly_Point *ppppp=cl->get_point_array();
-	IVP_ASSERT ( ((intp)ppppp & 15 ) == 0);
+	IVP_ASSERT ( ((hk_intp)ppppp & 15 ) == 0);
 
     // all triangles 
     const IVP_Compact_Triangle *tri = cl->get_first_triangle();
     for(int i=0; i<cl->get_n_triangles(); i++){
 	IVP_ASSERT(i == tri->get_tri_index());
 
-		IVP_ASSERT ( (intp(tri) & 15) == 0);
+		IVP_ASSERT ( (hk_intp(tri) & 15) == 0);
 
 	// all edges
 	for(int j=0; j<3; j++){

--- a/ivp_collision/ivp_compact_ledge_solver.hxx
+++ b/ivp_collision/ivp_compact_ledge_solver.hxx
@@ -234,7 +234,7 @@ const IVP_Compact_Poly_Point *IVP_Compact_Ledge_Solver::give_object_coords(const
     int point_index = edge->get_start_point_index();
     const IVP_Compact_Poly_Point *res = &clp->compact_poly_points[point_index];
 
-	IVP_ASSERT ( (intp(res) & 15) == 0);
+	IVP_ASSERT ( (hk_intp(res) & 15) == 0);
 
     return res;
 }

--- a/ivp_collision/ivp_mindist.cxx
+++ b/ivp_collision/ivp_mindist.cxx
@@ -310,7 +310,7 @@ public:
 class IVP_MM_CMP {
 public:
     static inline int calc_hash_index( IVP_MM_CMP_Key * o){
-	int x = (intp)o->ledge[0] ^ ( intp(o->ledge[1])* 75 );
+	int x = (hk_intp)o->ledge[0] ^ ( hk_intp(o->ledge[1])* 75 );
 	return x + 1023 * (x>>8);
     }
 
@@ -318,7 +318,7 @@ public:
     static inline int calc_hash_index( IVP_Collision *c, IVP_MM_CMP_Key * /*ref_key*/){
 	const IVP_Compact_Ledge *ledge[2];
 	c->get_ledges(ledge);
-    intp x = (intp)ledge[0] ^ ( intp(ledge[1])* 75 );
+    hk_intp x = (hk_intp)ledge[0] ^ ( hk_intp(ledge[1])* 75 );
 	return x + 1023 * (x>>8);
     }
 
@@ -627,7 +627,7 @@ void IVP_Mindist_Manager::insert_and_recalc_phantom_mindist( IVP_Mindist *new_mi
 class IVP_OO_CMP {
 public:
     static inline int calc_hash_index( IVP_Real_Object * o){
-    intp x = (intp)o;
+    hk_intp x = (hk_intp)o;
 	return x + 1023 * (x>>8);
     }
 
@@ -635,7 +635,7 @@ public:
     static inline int calc_hash_index( IVP_Collision *c, IVP_Real_Object * con){
 	IVP_Real_Object *objects[2];
 	c->get_objects(objects);
-    intp x = intp(objects[0]) ^ intp(objects[1]) ^ intp(con);  // take other object (trick to avoid if)
+    hk_intp x = hk_intp(objects[0]) ^ hk_intp(objects[1]) ^ hk_intp(con);  // take other object (trick to avoid if)
 	IVP_ASSERT( objects[0] == con || objects[1] == con );
 	return x + 1023 * (x>>8);
     }
@@ -886,7 +886,7 @@ void IVP_Mindist::update_exact_mindist_events(IVP_BOOL allow_hull_conversion, IV
 		IVP_Debug_Manager *dm=get_environment()->get_debug_manager();
 		if(dm->file_out_impacts) 
 		{
-			fprintf(dm->out_deb_file,"doing_mindist_events %zi at %f\n",0x0000ffff&(intp)this,get_environment()->get_current_time().get_time());
+			fprintf(dm->out_deb_file,"doing_mindist_events %zi at %f\n",0x0000ffff&(hk_intp)this,get_environment()->get_current_time().get_time());
 		}
 	}
 	

--- a/ivp_collision/ivp_mindist.cxx
+++ b/ivp_collision/ivp_mindist.cxx
@@ -880,7 +880,7 @@ void IVP_Mindist_Manager::recalc_all_exact_mindists(){
 /* check length, check for hull, check for coll events*/
 void IVP_Mindist::update_exact_mindist_events(IVP_BOOL allow_hull_conversion, IVP_MINDIST_EVENT_HINT event_hint)
 {
-	IVP_IFDEBUG(1,
+	IVP_IFDEBUG(IVP_TRUE,
 		IVP_ASSERT( mindist_status == IVP_MD_EXACT);
 		IVP_Debug_Manager *dm=get_environment()->get_debug_manager();
 		if(dm->file_out_impacts) 

--- a/ivp_collision/ivp_mindist.cxx
+++ b/ivp_collision/ivp_mindist.cxx
@@ -880,15 +880,14 @@ void IVP_Mindist_Manager::recalc_all_exact_mindists(){
 /* check length, check for hull, check for coll events*/
 void IVP_Mindist::update_exact_mindist_events(IVP_BOOL allow_hull_conversion, IVP_MINDIST_EVENT_HINT event_hint)
 {
-	IVP_IF(1) 
-	{
+	IVP_IFDEBUG(1,
 		IVP_ASSERT( mindist_status == IVP_MD_EXACT);
 		IVP_Debug_Manager *dm=get_environment()->get_debug_manager();
 		if(dm->file_out_impacts) 
 		{
 			fprintf(dm->out_deb_file,"doing_mindist_events %zi at %f\n",0x0000ffff&(hk_intp)this,get_environment()->get_current_time().get_time());
 		}
-	}
+	)
 	
 	IVP_Synapse_Real *syn0 = get_sorted_synapse(0);
 	IVP_Synapse_Real *syn1 = get_sorted_synapse(1);

--- a/ivp_collision/ivp_mindist.hxx
+++ b/ivp_collision/ivp_mindist.hxx
@@ -58,8 +58,8 @@ public:
   const IVP_Compact_Edge 	*edge;		// Note: all balls share one dummy edge
 
 protected:
-    // dimhotepus: short -> intp.
-    intp mindist_offset;             // back link to my controlling mindist
+    // dimhotepus: short -> hk_intp.
+    hk_intp mindist_offset;             // back link to my controlling mindist
     short status;                     // IVP_SYNAPSE_POLYGON_STATUS point, edge, tri, ball ....
 public:
    
@@ -74,7 +74,7 @@ public:
     IVP_Real_Object *get_object(){ return l_obj; }
     IVP_SYNAPSE_POLYGON_STATUS get_status()const{ return (IVP_SYNAPSE_POLYGON_STATUS) status; }
 
-    IVP_Synapse() : next{nullptr}, prev{nullptr}, l_obj{nullptr}, edge{nullptr}, mindist_offset{std::numeric_limits<intp>::max()}, status{SHRT_MAX} {}
+    IVP_Synapse() : next{nullptr}, prev{nullptr}, l_obj{nullptr}, edge{nullptr}, mindist_offset{std::numeric_limits<hk_intp>::max()}, status{SHRT_MAX} {}
     virtual ~IVP_Synapse(){}			// dummy, do not call
     const IVP_Compact_Ledge *get_ledge() const;
     const IVP_Compact_Edge *get_edge() const { return edge; }

--- a/ivp_collision/ivp_mindist_debug.cxx
+++ b/ivp_collision/ivp_mindist_debug.cxx
@@ -42,7 +42,7 @@ IVP_BOOL ivp_check_debug_mindist( IVP_Mindist *md){
 		(!P_String::string_cmp(name0, search1, IVP_FALSE) && !P_String::string_cmp(name1, search0, IVP_FALSE))){
 	const IVP_Time &time = md->get_synapse(0)->l_obj->get_environment()->get_current_time();
 	if ( time - IVP_DEBUG_TIME >= 0.0f){
-	    ivp_message("%10s %10s %8f-%X: ", name0, name1, time.get_time(), (int)((intp)md & 0xffff) );
+	    ivp_message("%10s %10s %8f-%X: ", name0, name1, time.get_time(), (int)((hk_intp)md & 0xffff) );
 	    return IVP_TRUE;
 	}
     }

--- a/ivp_collision/ivp_mindist_minimize.cxx
+++ b/ivp_collision/ivp_mindist_minimize.cxx
@@ -92,8 +92,8 @@ IVP_BOOL IVP_Mindist_Minimize_Solver::check_loop_hash(IVP_SYNAPSE_POLYGON_STATUS
     IVP_ASSERT( i_s0 < 4);
     IVP_ASSERT( i_s1 < 4);
 
-    intp x0 = intp(i_e0) | i_s0;
-    intp x1 = intp(i_e1) | i_s1;
+    hk_intp x0 = hk_intp(i_e0) | i_s0;
+    hk_intp x1 = hk_intp(i_e1) | i_s1;
 
     if (x0 < x1) {
 	int h = x0; x0 = x1; x1 = h;

--- a/ivp_compact_builder/geompack_cutfac.cxx
+++ b/ivp_compact_builder/geompack_cutfac.cxx
@@ -772,9 +772,9 @@ L110:
 	for (i__ = 1; i__ <= i__1; ++i__) {
 	    if (lw1 == this->g_ev[i__ - 1]) {
 		IVP_IF(1) {
-		    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL3) {
+		    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL3, {
 			ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL3, "Rejected due to simply-connected polygon: case 1\n");
-		    }
+		    })
 		}
 		return;
 	    }
@@ -810,9 +810,9 @@ recheck_size_2:
 /* L130: */
 	    }
 	    IVP_IF(1) {
-		IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL3) {
+		IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL3, {
 		    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL3, "Rejected due to simply-connected polygon: case 2\n");
-		}
+		})
 	    }
 	    return;
 L140:
@@ -885,9 +885,9 @@ L150:
     }
     if ( (angr < this->angacc) || ang - angr < this->angacc ) {
 	IVP_IF(1) {
-	    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL3) {
+	    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL3, {
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL3, "Rejected due to small angle\n");
-	    }
+	    })
 	}
 	return;
     }
@@ -957,9 +957,9 @@ L150:
     }
     if (s < 0.) {
 	IVP_IF(1) {
-	    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL3) {
+	    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL3, {
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL3, "Rejected due to inner boundary\n");
-	    }
+	    })
 	}
 	return;
     }
@@ -1045,9 +1045,9 @@ L190:
 
 	if (inout == 1) {
 	    IVP_IF(1) {
-		IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL3) {
+		IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL3, {
 		    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL3, "Rejected due to hole polygon\n");
-		}
+		})
 	    }
 	    return;
 	}
@@ -1055,13 +1055,13 @@ L190:
     }
     *rflag = 1;
     IVP_IF(1) {
-	IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL3) {
+	IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL3, {
 	    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL3, "CEDGE(1:2), CDANG\n");
 	    i__1 = *nce;
 	    for (i__ = 1; i__ <= i__1; ++i__) {
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL3, "%d %d %d %f\n", i__, cedge[(i__ << 1) + 1], cedge[(i__ << 1) + 2], cdang[i__] * 180.0 / IVP_PI);
 	    }
-  	}
+  	})
     }
 
     return;

--- a/ivp_compact_builder/geompack_cvdec3.cxx
+++ b/ivp_compact_builder/geompack_cvdec3.cxx
@@ -117,9 +117,9 @@ L20:
 	if (n == 0) {
 	    this->ierr = 327;
 	    IVP_IF(1) {
-		IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1) {
+		IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1, {
 		    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "*** GEOMPACK: at least one reflex edge has not been resolved by routine RESEDG\n");
-		}
+		})
 	    }
 	    return;
 	} else {

--- a/ivp_compact_builder/geompack_drdec3.cxx
+++ b/ivp_compact_builder/geompack_drdec3.cxx
@@ -116,9 +116,9 @@ void IVP_Geompack::decompose(struct geompack_parameters *params) {
 
     if ( !this->g_facesdata || !this->g_facestype || !this->g_hashtable || !this->g_polyhedronfirstfaceoffset || !this->g_polyhedronfaceindices || !this->g_faceverticeslist || !this->g_intworkarray || !this->g_doubleworkarray || !this->g_edge_angles || !this->g_normals || !this->g_ev ) {
 	IVP_IF(1) {
-	    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1) {
+	    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1, {
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "*** GEOMPACK: Out of memory!\n\n");
-	    }
+	    })
 	}
 	goto out_of_memory;
     }
@@ -187,12 +187,12 @@ void IVP_Geompack::decompose(struct geompack_parameters *params) {
 
     if (this->ierr != 0) {
 	IVP_IF(1) {
-	    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1) {
+	    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1, {
 		if ( this->ierr == 500 ) {
 		    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "*** GEOMPACK: Out of memory!\n\n");
 		}
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "Premature abort due to above error.\n\n");
-	    }
+	    })
 	}
 	goto GEOMPACK_abort;
     }
@@ -200,7 +200,7 @@ void IVP_Geompack::decompose(struct geompack_parameters *params) {
 
 
     IVP_IF(1) {
-	IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1) {
+	IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1, {
 	    int	n_reflex_edges;
 	    double	minimum_angle;
 	    int mem_iwa;
@@ -235,7 +235,7 @@ void IVP_Geompack::decompose(struct geompack_parameters *params) {
 	    mem_fl    = this->size_facearrays*sizeof(int)+this->size_facearrays*3*sizeof(int)+this->size_facearrays*3*sizeof(double);
 	    mem_fvl   = this->size_facevertexarrays*6*sizeof(int)+this->size_facevertexarrays*sizeof(double);
 	    mem_total = mem_iwa+ mem_dwa + mem_vcl + mem_pffl + mem_pfil + mem_fl + mem_fvl;
-	    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL2) {
+	    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL2, {
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL2, "Memory allocated for int WORK ARRAY: %d bytes\n"        , mem_iwa);
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL2, "Memory allocated for DOUBLE WORK ARRAY: %d bytes\n"         , mem_dwa);
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL2, "Memory allocated for VERTEX COORDINATE LIST: %d bytes\n"    , mem_vcl);
@@ -243,7 +243,7 @@ void IVP_Geompack::decompose(struct geompack_parameters *params) {
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL2, "Memory allocated for POLYHEDRON FACE INDEX LIST: %d bytes\n", mem_pfil);
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL2, "Memory allocated for FACE LISTS: %d bytes\n"                , mem_fl);
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL2, "Memory allocated for FACE VERTICES LISTS: %d bytes\n"       , mem_fvl);
-	    }
+	    })
 	    else {
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "Total memory allocated: %d bytes\n", mem_total);
 	    }
@@ -255,7 +255,7 @@ void IVP_Geompack::decompose(struct geompack_parameters *params) {
 	    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "N_REFLEX_EDGES      = %d\n", n_reflex_edges);
 	    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "MINIMUM_ANGLE       = %f\n", minimum_angle);
 	    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "\n");
-	}
+	})
     }
 
 
@@ -272,12 +272,12 @@ Retry_convex_decomposition:
 
     if ( (this->ierr != 0) && (this->ierr != 327) ) { // abort on error but skip "reflex edge" resolving problems
 	IVP_IF(1) {
-	    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1) {
+	    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1, {
 		if ( this->ierr == 500 ) {
 		    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "*** GEOMPACK: Out of memory!\n\n");
 		}
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "Premature abort due to above error.\n\n");
-	    }
+	    })
 	}
 	goto GEOMPACK_abort;
     }
@@ -285,7 +285,7 @@ Retry_convex_decomposition:
 
 
     IVP_IF(1) {
-	IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1) {
+	IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1, {
 	    int	n_reflex_edges;
 	    double	minimum_angle;
 	    int mem_iwa;
@@ -320,7 +320,7 @@ Retry_convex_decomposition:
 	    mem_fl    = this->size_facearrays*sizeof(int)+this->size_facearrays*3*sizeof(int)+this->size_facearrays*3*sizeof(double);
 	    mem_fvl   = this->size_facevertexarrays*6*sizeof(int)+this->size_facevertexarrays*sizeof(double);
 	    mem_total = mem_iwa+ mem_dwa + mem_vcl + mem_pffl + mem_pfil + mem_fl + mem_fvl;
-	    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL2) {
+	    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL2, {
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL2, "Memory allocated for int WORK ARRAY: %d bytes\n"        , mem_iwa);
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL2, "Memory allocated for DOUBLE WORK ARRAY: %d bytes\n"         , mem_dwa);
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL2, "Memory allocated for VERTEX COORDINATE LIST: %d bytes\n"    , mem_vcl);
@@ -328,7 +328,7 @@ Retry_convex_decomposition:
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL2, "Memory allocated for POLYHEDRON FACE INDEX LIST: %d bytes\n", mem_pfil);
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL2, "Memory allocated for FACE LISTS: %d bytes\n"                , mem_fl);
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL2, "Memory allocated for FACE VERTICES LISTS: %d bytes\n"       , mem_fvl);
-	    }
+	    })
 	    else {
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "Total memory allocated: %d bytes\n", mem_total);
 	    }
@@ -340,7 +340,7 @@ Retry_convex_decomposition:
 	    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "N_REFLEX_EDGES      = %d\n", n_reflex_edges);
 	    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "MINIMUM_ANGLE       = %f\n", minimum_angle);
 	    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "\n");
-	}
+	})
     }
 
 
@@ -353,17 +353,17 @@ Retry_convex_decomposition:
 		this->ierr = 0;
 		retry_counter++;
 		IVP_IF(1) {
-		    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1) {
+		    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1, {
 			ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "Retrying with <angacc=%f> and <rdacc=%f>\n\n", this->angacc, this->rdacc);
-		    }
+		    })
 		}
 		goto Retry_convex_decomposition;
 	    }
 	}
 	IVP_IF(1) {
-	    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1) {
+	    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1, {
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "Premature abort due to difficulties in resolving some reflex edge(s).\n\n");
-	    }
+	    })
 	}
 	goto GEOMPACK_abort;
     }
@@ -374,11 +374,11 @@ Retry_convex_decomposition:
     // -----------------------------------------------------------------------
 
     IVP_IF(1) {
-	IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1) {
+	IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1, {
 	    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "+++ Convex decomposition successful!\n\n");
-	}
+	})
 
-	IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL2) {
+	IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL2, {
 	    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL2, "VCL (vertex coordinate list)\n");
 	    for (i=1; i<=this->n_original_vertices; i++) {
 		int j;
@@ -436,7 +436,7 @@ Retry_convex_decomposition:
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL2, "\t(%f Grad)\n", this->g_edge_angles[i-1]/IVP_PI*180.0);
 	    }
 	    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL2, "\n\n");
-	}
+	})
 
 #if 0
 	s_wsfe(&io___90);
@@ -462,14 +462,14 @@ Retry_convex_decomposition:
 GEOMPACK_abort:
 
     IVP_IF(1) {
-	IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1) {
+	IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1, {
 	    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "Final GEOMPACK statistics:\n");
 	    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "N_ORIGINAL_VERTICES   \t= %d (number of vertex coordinates)\n", this->n_original_vertices);
 	    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "NFACE \t= %d (number of faces in polyhedral decomposition)\n", this->nface);
 	    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "N_WORK_VERTICES \t= %d (number of positions used in FVL array)\n", this->n_work_vertices);
 	    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "NPOLH \t= %d (number of polyhedra in decomposition)\n", this->npolh);
 	    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "\n\n");
-	}
+	})
     }
 
     *n_original_vertices_out	= this->n_original_vertices;

--- a/ivp_compact_builder/geompack_dsphdc.cxx
+++ b/ivp_compact_builder/geompack_dsphdc.cxx
@@ -180,9 +180,9 @@ void IVP_Geompack::dsphdc_() {
 	if (facesdata[f * 3 + 2] * facesdata[f * 3 + 3] > 0) {
 	    this->ierr = 321;
 	    IVP_IF(1) {
-		IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1) {
+		IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1, {
 		    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "*** GEOMPACK: face oriented same way twice in routine DSPHDC\n");
-		}
+		})
 	    }
 	    return;
 	}
@@ -312,9 +312,9 @@ void IVP_Geompack::dsphdc_() {
 	if (nht != 0) {
 	    this->ierr = 322;
 	    IVP_IF(1) {
-		IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1) {
+		IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL1, {
 		    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL1, "*** GEOMPACK: unmatched edge determined by routine DSPHDC\n");
-		}
+		})
 	    }
 	    return;
 	}

--- a/ivp_compact_builder/geompack_insfac.cxx
+++ b/ivp_compact_builder/geompack_insfac.cxx
@@ -620,7 +620,7 @@ L230:
 
 L240:
     IVP_IF(1) {
-	IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL2) {
+	IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL2, {
 	    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL2, "Cut face: #edges, polyh(1:2) = %d %d %d\n", (*nce), facesdata[this->nface * 3 + 2], facesdata[this->nface * 3 + 3]);
 	    i__1 = *nce;
 	    for (i__ = 1; i__ <= i__1; ++i__) {
@@ -633,7 +633,7 @@ L240:
 
 	    }
 	    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL2, "\n");
-	}
+	})
     }
 
     return;

--- a/ivp_compact_builder/geompack_resedg.cxx
+++ b/ivp_compact_builder/geompack_resedg.cxx
@@ -161,9 +161,9 @@ void IVP_Geompack::resedg_(
 	lvo = lu;
     }
     IVP_IF(1) {
-	IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL3) {
+	IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL3, {
 	    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL3, "RESEDG: U,V,LU,LV,FL,FR,P = %d %d %d %d %d %d %d\n", u_in, v, lu, lv, fl, fr, p);
-	}
+	})
     }
 
 /*     Determine edges in polyhedron P and average edge length. */
@@ -487,12 +487,12 @@ L70:
     }
 L80:
     IVP_IF(1) {
-	IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL3) {
+	IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL3, {
 	    ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL3, "Candidate angles (dihedral angle = %f ", edge_angles[u_in] * 180.0 / IVP_PI);
 	    for (i__ = 1; i__ <= nang; ++i__) {
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL3, "%f ", ang[i__ - 1] * 180.0 / IVP_PI);
 	    }
-	}
+	})
     }
 
 /*     For each angle in ANG array, try to resolve reflex edge as */
@@ -563,9 +563,9 @@ L90:
 	intworkarray[(n_edges + 2) * 3 + 1] = u_in;
 	doubleworkarray[1] = ang[i__ - 1];
 	IVP_IF(1) {
-	    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL3) {
+	    IVP_IFDEBUG(IVP_DM_GEOMPACK_LEVEL3, {
 		ivp_debugmanager.dprint(IVP_DM_GEOMPACK_LEVEL3, "Trying angle %d   NEDGC = %d\n", i__, nedgc);
-	    }
+	    })
 	}
 
 	// *******************************************************************

--- a/ivp_compact_builder/ivp_compact_ledge_gen.cxx
+++ b/ivp_compact_builder/ivp_compact_ledge_gen.cxx
@@ -97,7 +97,7 @@ int IVP_Compact_Ledge_Generator::prepare_compact_ledge(IVP_U_Vector<IVP_Triangle
 		c_edge->set_start_point_index(edge->start_point->tmp.compact_index);
 
 		IVP_ASSERT(edge_hash->find((char *)&edge) == (void *)-1);
-		edge_hash->add((char *)&edge, (void *)(intp)(i * 4 + j + 1));	// for opposites //-V112
+		edge_hash->add((char *)&edge, (void *)(hk_intp)(i * 4 + j + 1));	// for opposites //-V112
 		edge_cnt++;
 	    }
 	}
@@ -118,7 +118,7 @@ int IVP_Compact_Ledge_Generator::prepare_compact_ledge(IVP_U_Vector<IVP_Triangle
 	    for(j=0; j<3; e = e->next, j++){
 		IVP_Compact_Edge *c_edge = &c_tri->c_three_edges[j];
 		IVP_Tri_Edge *opp = e->opposite;
-        intp opp_index = (intp)edge_hash->find((char *)&opp);
+        hk_intp opp_index = (hk_intp)edge_hash->find((char *)&opp);
 		IVP_ASSERT(opp_index>=0);
 		int rel_index = opp_index - (i*4 + j + 1); //-V112
 		c_edge->set_opposite_index(rel_index);
@@ -206,7 +206,7 @@ IVP_RETURN_TYPE IVP_Compact_Ledge_Generator::validate()
 	for(j=0; j<3; edge=edge->next,j++){
 	    const IVP_Compact_Edge *c_edge = &c_tri->c_three_edges[j];
 
-        intp opp_index = (intp)edge_hash->find((char *)&edge->opposite);
+        hk_intp opp_index = (hk_intp)edge_hash->find((char *)&edge->opposite);
 	    IVP_ASSERT(opp_index>=0);
 	    int rel_index = opp_index - (i*sizeof(IVP_Compact_Edge) + j + 1);
 	    IVP_ASSERT(rel_index == c_edge->get_opposite_index());

--- a/ivp_compact_builder/ivp_compact_recursive.cxx
+++ b/ivp_compact_builder/ivp_compact_recursive.cxx
@@ -103,9 +103,9 @@ void IVP_Compact_Recursive::set_rekursive_convex_hull(){
       int pi[3];
       // convert points to unique point nums
       for (int i = 0; i<3;i++){
-	int ind = (int)(intp)point_hash.find( (const char *)p[i]);
+	int ind = (int)(hk_intp)point_hash.find( (const char *)p[i]);
 	if (ind<0){
-	  point_hash.add( (const char *)p[i], (void *)static_cast<intp>(n_points_in_hash));
+	  point_hash.add( (const char *)p[i], (void *)static_cast<hk_intp>(n_points_in_hash));
 	  ind = n_points_in_hash++;
 	}
 	pi[i] = ind;
@@ -141,7 +141,7 @@ void IVP_Compact_Recursive::set_rekursive_convex_hull(){
       int pi[3];
       // convert points to unique point nums
       for (int i = 0; i<3;i++){
-    int ind = (int)(intp)point_hash.find( (const char *)p[i]);
+    int ind = (int)(hk_intp)point_hash.find( (const char *)p[i]);
 	pi[i] = ind;
       }
       // find triangle in hash

--- a/ivp_compact_builder/ivp_convex_decompositor.cxx
+++ b/ivp_compact_builder/ivp_convex_decompositor.cxx
@@ -9,7 +9,7 @@
 
 
 
-void IVP_Concave_Polyhedron_Face::add_offset(intp offset_in) {
+void IVP_Concave_Polyhedron_Face::add_offset(hk_intp offset_in) {
 
     IVP_Concave_Polyhedron_Face_Pointoffset *p_offset = new IVP_Concave_Polyhedron_Face_Pointoffset();
     p_offset->offset = offset_in;
@@ -51,11 +51,11 @@ class IVP_Convex_Subpart_Work {
 public:
     IVP_U_Vector<int> offsets; // @@@SF: replace with IVP_VHash someday!!!
 
-    void add_offset(intp offset_in);
+    void add_offset(hk_intp offset_in);
 };
 
 
-void IVP_Convex_Subpart_Work::add_offset(intp offset_in) {
+void IVP_Convex_Subpart_Work::add_offset(hk_intp offset_in) {
 
     int i;
     for (i=0; i<this->offsets.len(); i++) {
@@ -294,7 +294,7 @@ fclose(fp);
 	    }
 	    int j;
 	    for (j=0; j<subpart_work->offsets.len(); j++) {
-        intp offset = (intp)subpart_work->offsets.element_at(j)-1;
+        hk_intp offset = (hk_intp)subpart_work->offsets.element_at(j)-1;
 		IVP_U_Point *point = new IVP_U_Point();
 		point->k[0] = vcl_out[(offset*3)+0];
 		point->k[1] = vcl_out[(offset*3)+1];

--- a/ivp_compact_builder/ivp_convex_decompositor.cxx
+++ b/ivp_compact_builder/ivp_convex_decompositor.cxx
@@ -114,11 +114,11 @@ int IVP_Convex_Decompositor::perform_convex_decomposition_on_concave_polyhedron(
 	// alloc an array for n points, consisting of 3 floats each
 	vcl = (double *)p_calloc(n_points*3, sizeof(double));
 	if ( !vcl ) {
-	    IVP_IFDEBUG(IVP_DEBUG_IPION_ERROR_MSG) {
+	    IVP_IFDEBUG(IVP_DEBUG_IPION_ERROR_MSG, {
 		ivp_debugmanager.dprint(IVP_DEBUG_IPION_ERROR_MSG,
 					"IVP_Convex_Decompositor::perform_convex_decomposition_on_concave_polyhedron()\n"
 					"Not enough memory to allocate 'points_list' (needed: %d bytes)\n", n_points*3*sizeof(float));
-	    }
+	    })
 	    return(0);
 	}
 
@@ -288,9 +288,9 @@ fclose(fp);
 	    IVP_Convex_Subpart_Work *subpart_work = subparts_offsets.element_at(i);
 	    IVP_Convex_Subpart *subpart = convex_subparts_out->element_at(i);
 	    IVP_IF(1) {
-		IVP_IFDEBUG(IVP_DM_CONVEX_DECOMPOSITOR) {
+		IVP_IFDEBUG(IVP_DM_CONVEX_DECOMPOSITOR, {
 		    ivp_debugmanager.dprint(IVP_DM_CONVEX_DECOMPOSITOR, "Points of convex subpart:\n");
-		}
+		})
 	    }
 	    int j;
 	    for (j=0; j<subpart_work->offsets.len(); j++) {
@@ -300,9 +300,9 @@ fclose(fp);
 		point->k[1] = vcl_out[(offset*3)+1];
 		point->k[2] = vcl_out[(offset*3)+2];
 		IVP_IF(1) {
-		    IVP_IFDEBUG(IVP_DM_CONVEX_DECOMPOSITOR) {
+		    IVP_IFDEBUG(IVP_DM_CONVEX_DECOMPOSITOR, {
 			ivp_debugmanager.dprint(IVP_DM_CONVEX_DECOMPOSITOR, "   %.6f %.6f %.6f\n", point->k[0], point->k[1], point->k[2]);
-		    }
+		    })
 		}
 		subpart->points.add(point);
 	    }

--- a/ivp_compact_builder/ivp_convex_decompositor.hxx
+++ b/ivp_compact_builder/ivp_convex_decompositor.hxx
@@ -62,7 +62,7 @@ public:
      *  Description:    Use this method to add a new point offset to the list.
      *	Note:		This method will drop any duplicate offsets.
      *****************************************************************************/
-    void add_offset(intp offset);
+    void add_offset(hk_intp offset);
 
     ~IVP_Concave_Polyhedron_Face();
 };

--- a/ivp_compact_builder/ivp_object_polygon_tetra.cxx
+++ b/ivp_compact_builder/ivp_object_polygon_tetra.cxx
@@ -138,7 +138,7 @@ void IVP_Tri_Edge::print(const char *text){
     if (!text) text = "";
     const char *name = start_point->get_real_object2()->get_name();
     if (!name) name = "noname";
-    ivp_message("%s '%s'	start_%zi: %i	",text,name, 0xff & ( ( (intp)this->start_point->l_tetras  ) >>8), this->start_point->point_num());
+    ivp_message("%s '%s'	start_%zi: %i	",text,name, 0xff & ( ( (hk_intp)this->start_point->l_tetras  ) >>8), this->start_point->point_num());
     this->triangle->print("\n");
 }
 

--- a/ivp_compact_builder/ivp_surbuild_ledge_soup.cxx
+++ b/ivp_compact_builder/ivp_surbuild_ledge_soup.cxx
@@ -105,9 +105,9 @@ IVP_SurfaceBuilder_Ledge_Soup::~IVP_SurfaceBuilder_Ledge_Soup() = default;
 void IVP_SurfaceBuilder_Ledge_Soup::insert_ledge(IVP_Compact_Ledge *c_ledge)
 {
   if (!c_ledge){
-    IVP_IFDEBUG(IVP_DM_SURBUILD_LEDGESOUP) {
+    IVP_IFDEBUG(IVP_DM_SURBUILD_LEDGESOUP, {
       ivp_debugmanager.dprint(IVP_DM_SURBUILD_LEDGESOUP, "warning: tried to add NULL ledge in IVP_SurfaceBuilder_Ledge_Soup::insert_ledge()\n");
-    }
+    })
     return;
 
   }

--- a/ivp_compact_builder/ivp_surbuild_ledge_soup.cxx
+++ b/ivp_compact_builder/ivp_surbuild_ledge_soup.cxx
@@ -532,8 +532,8 @@ void IVP_SurfaceBuilder_Ledge_Soup::cluster_spheres_bottomup(IVP_DOUBLE threshol
 		
 		// retrieve smallest mothersphere (if available!)
 		IVV_Cluster_Min_Hash_Key key;
-		key.key = (uintp)cluster_min_hash.find_min_elem();
-		if ( key.key != (uintp)NULL ) { // verify that there were at least 2 spheres in vector and a new minimal sphere could be generated!
+		key.key = (hk_uintp)cluster_min_hash.find_min_elem();
+		if ( key.key != (hk_uintp)NULL ) { // verify that there were at least 2 spheres in vector and a new minimal sphere could be generated!
 		    //IVP_DOUBLE radius = cluster_min_hash->find_min_value(); // radius of minimal sphere
 		    int sphere_1_number = key.spheres.s1;
 		    int sphere_2_number = key.spheres.s2;
@@ -601,12 +601,12 @@ void IVP_SurfaceBuilder_Ledge_Soup::generate_interval_minhash(float fixed_max_ra
 
 	// insert interval start into interval MinHash
 	IVP_Clustering_Shortrange_Interval_Min_Hash_Entry *new_entry_interval_start = new IVP_Clustering_Shortrange_Interval_Min_Hash_Entry(IVP_TRUE, sphere);
-	new_key.key = (uintp)new_entry_interval_start;
+	new_key.key = (hk_uintp)new_entry_interval_start;
 	this->interval_minhash->add((void *)new_key.key, sphere->center.k[this->longest_axis]-radius);
 
 	// insert interval end into interval MinHash
 	IVP_Clustering_Shortrange_Interval_Min_Hash_Entry *new_entry_interval_end = new IVP_Clustering_Shortrange_Interval_Min_Hash_Entry(IVP_FALSE, sphere);
-	new_key.key = (uintp)new_entry_interval_end;
+	new_key.key = (hk_uintp)new_entry_interval_end;
 	this->interval_minhash->add((void *)new_key.key, sphere->center.k[this->longest_axis]+radius);
 
     }
@@ -1304,7 +1304,7 @@ void IVP_SurfaceBuilder_Ledge_Soup::insert_compact_ledges(){
        	    IVV_Sphere *sphere = this->terminal_spheres.element_at(i);
 	    IVP_Compact_Ledge *source = sphere->compact_ledge;
 
-	    IVP_ASSERT((intp(dest) & 0xf) == 0);
+	    IVP_ASSERT((hk_intp(dest) & 0xf) == 0);
 
 	    sphere->compact_ledge = (IVP_Compact_Ledge *)dest;	    
 	    int ledge_size = recompile_point_indizes_of_compact_ledge(source,dest);
@@ -1319,7 +1319,7 @@ void IVP_SurfaceBuilder_Ledge_Soup::insert_compact_ledges(){
        	IVV_Sphere *sphere = this->rec_spheres.element_at(j);
 	IVP_Compact_Ledge *source = sphere->compact_ledge;
 
-	IVP_ASSERT((intp(dest) & 0xf) == 0);
+	IVP_ASSERT((hk_intp(dest) & 0xf) == 0);
 
 	sphere->compact_ledge = (IVP_Compact_Ledge *)dest;
 	
@@ -1344,8 +1344,8 @@ IVP_Compact_Ledgetree_Node *IVP_SurfaceBuilder_Ledge_Soup::build_ledgetree(IVV_S
 
     IVP_Compact_Ledgetree_Node *current_node = this->ledgetree_work;
 
-    IVP_ASSERT((intp)current_node <  (intp)this->clt_highmem); // ledgetree memory overwrite!
-    IVP_ASSERT((intp)current_node >= (intp)this->clt_lowmem);  // ledgetree memory underwrite!
+    IVP_ASSERT((hk_intp)current_node <  (hk_intp)this->clt_highmem); // ledgetree memory overwrite!
+    IVP_ASSERT((hk_intp)current_node >= (hk_intp)this->clt_lowmem);  // ledgetree memory underwrite!
 	
     this->ledgetree_work++;
     
@@ -1397,8 +1397,8 @@ void IVP_SurfaceBuilder_Ledge_Soup::ledgetree_debug_output(const IVP_Compact_Led
 {
     // *** debugging START ******************************************************
     IVP_IF(1) {
-	IVP_ASSERT((intp)node < (intp)this->clt_highmem); // ledgetree memory overread!
-	IVP_ASSERT((intp)node >= (intp)this->clt_lowmem); // ledgetree memory underread!
+	IVP_ASSERT((hk_intp)node < (hk_intp)this->clt_highmem); // ledgetree memory overread!
+	IVP_ASSERT((hk_intp)node >= (hk_intp)this->clt_lowmem); // ledgetree memory underread!
     }
     
     //for (int x=0; x<ivp_debug_sf_indent; x++) {

--- a/ivp_compact_builder/ivp_surbuild_pointsoup.cxx
+++ b/ivp_compact_builder/ivp_surbuild_pointsoup.cxx
@@ -334,7 +334,7 @@ IVP_Compact_Ledge *IVP_SurfaceBuilder_Pointsoup::try_to_build_convex_ledge_from_
 	    point_indizes.remove_all();
 	    FOREACHvertex_(vertices) {
 		int point_index = qh_pointid(vertex->point);
-		point_indizes.add( reinterpret_cast<int*>(static_cast<intp>(point_index)) );
+		point_indizes.add( reinterpret_cast<int*>(static_cast<hk_intp>(point_index)) );
 		plane->points.add(points->element_at(point_index));
 		use_list[point_index] ++;
 	    }
@@ -357,7 +357,7 @@ IVP_Compact_Ledge *IVP_SurfaceBuilder_Pointsoup::try_to_build_convex_ledge_from_
 	      int max_index = 0;
 	      int max_index2 = 0;
 	      for (int i0 = 0; i0 < point_indizes.len(); i0++){
-        intp in = intp(point_indizes.element_at(i0));
+        hk_intp in = hk_intp(point_indizes.element_at(i0));
 		if (skip_list[in]) goto no_point_skipped;
 		IVP_U_Point *p2 = plane->points.element_at( i0 );
 		IVP_DOUBLE dist = plane->points.element_at( 0 )->quad_distance_to(p2);
@@ -384,7 +384,7 @@ IVP_Compact_Ledge *IVP_SurfaceBuilder_Pointsoup::try_to_build_convex_ledge_from_
 	      {
 		  for (int i2 = 0; i2 < point_indizes.len(); i2++){
 		    if (i2 != max_index2 && i2 != max_index) {
-              intp in = intp(point_indizes.element_at(i2));
+              hk_intp in = hk_intp(point_indizes.element_at(i2));
 		      skip_list[in]++;
 		      IVP_ASSERT( use_list[in] );
 		      //ivp_message("point removed %i %i\n",in, points->len());

--- a/ivp_compact_builder/ivp_surbuild_pointsoup.cxx
+++ b/ivp_compact_builder/ivp_surbuild_pointsoup.cxx
@@ -282,6 +282,7 @@ IVP_DOUBLE IVP_SurMan_PS_Plane::get_qlen_of_all_edges(){
 
 void IVP_SurfaceBuilder_Pointsoup::error_output(IVP_Template_Polygon *templ)
 {
+	IVP_DEBUGCODE(
 //    ivp_debugmanager.dprint(IVP_DM_SURBUILD_POINTSOUP, "IVP_SurfaceBuilder_Pointsoup::convert_pointsoup_to_compact_ledge_internal() - failed to triangulize object!\n");
     ivp_debugmanager.dprint(IVP_DM_SURBUILD_POINTSOUP, "Object points:\n");
     int i;
@@ -296,6 +297,7 @@ void IVP_SurfaceBuilder_Pointsoup::error_output(IVP_Template_Polygon *templ)
 	ivp_debugmanager.dprint(IVP_DM_SURBUILD_POINTSOUP, "Distance [%d] - [%d] : %f\n", p0, p1, templ->points[p0].quad_distance_to(&templ->points[p1]));
     }
     ivp_debugmanager.dprint(IVP_DM_SURBUILD_POINTSOUP, "\n");
+	)
     return;
 }
 
@@ -307,13 +309,13 @@ IVP_Compact_Ledge *IVP_SurfaceBuilder_Pointsoup::try_to_build_convex_ledge_from_
   *skip_point = IVP_FALSE;
   // DEBUG: Print all vertices of convex hull
 	IVP_IF(1) {
-	    IVP_IFDEBUG(IVP_DM_SURBUILD_POINTSOUP) {
+	    IVP_IFDEBUG(IVP_DM_SURBUILD_POINTSOUP, {
 		vertexT *vertex;	    /* set by FORALLvertices */
 		FORALLvertices {
 		    int point_index = qh_pointid(vertex->point);
 		    ivp_debugmanager.dprint(IVP_DM_SURBUILD_POINTSOUP, "Point in convex hull: %f %f %f\n", points->element_at(point_index)->k[0], points->element_at(point_index)->k[1], points->element_at(point_index)->k[2]);
 		}
-	    }
+	    })
 	}
 	
 	IVP_U_Vector<IVP_SurMan_PS_Plane> planes;
@@ -398,12 +400,12 @@ IVP_Compact_Ledge *IVP_SurfaceBuilder_Pointsoup::try_to_build_convex_ledge_from_
 	    
 	    qh_settempfree(&vertices);
 	    IVP_IF(0) {
-		IVP_IFDEBUG(IVP_DM_SURBUILD_POINTSOUP) {
+		IVP_IFDEBUG(IVP_DM_SURBUILD_POINTSOUP, {
 		    ivp_debugmanager.dprint(IVP_DM_SURBUILD_POINTSOUP, "n_faces: %d\n", plane->points.len());
 		    if ( plane->points.len() > 3 ) { //@@@SF: Debug [14.12.1999]
 			ivp_debugmanager.dprint(IVP_DM_SURBUILD_POINTSOUP, "[Testing/Debug] Qhull : more than 3 points on plane!\n");
 		    }
-		}
+		})
 	    }
 	}
 
@@ -418,11 +420,11 @@ IVP_Compact_Ledge *IVP_SurfaceBuilder_Pointsoup::try_to_build_convex_ledge_from_
 	  // -----------------------------------------
 	  compact_ledge = IVP_SurfaceBuilder_Polygon_Convex::convert_template_to_ledge(templ);
 	  IVP_IF(1) {
-	    IVP_IFDEBUG(IVP_DM_SURBUILD_POINTSOUP) {
+	    IVP_IFDEBUG(IVP_DM_SURBUILD_POINTSOUP, {
 	      if ( !compact_ledge ) {
 		error_output(templ);
 	      }
-	    }
+	    })
 	  }
 	  P_DELETE(templ);
 	}
@@ -442,9 +444,9 @@ IVP_Compact_Ledge *IVP_SurfaceBuilder_Pointsoup::try_to_build_convex_ledge_from_
 IVP_Compact_Ledge *IVP_SurfaceBuilder_Pointsoup::convert_pointsoup_to_compact_ledge_internal(IVP_U_Vector<IVP_U_Point> *points_in)
 {
     IVP_IF(1) {
-	IVP_IFDEBUG(IVP_DM_SURBUILD_POINTSOUP) {
+	IVP_IFDEBUG(IVP_DM_SURBUILD_POINTSOUP, {
 	    ivp_debugmanager.dprint(IVP_DM_SURBUILD_POINTSOUP, "*** Starting building new convex hull from pointsoup.\n");
-	}
+	})
     }
 
 
@@ -509,9 +511,9 @@ IVP_Compact_Ledge *IVP_SurfaceBuilder_Pointsoup::convert_pointsoup_to_compact_le
 	  qhull_free_flag = IVP_TRUE;
       }
       if ( exitcode || !try_unjumbled) {      
-	IVP_IFDEBUG(IVP_DM_SURBUILD_POINTSOUP) {
+	IVP_IFDEBUG(IVP_DM_SURBUILD_POINTSOUP, {
 	  ivp_debugmanager.dprint(IVP_DM_SURBUILD_POINTSOUP, "*** Qhull failed. Retrying with different parameters.\n");
-	}
+	})
 
 	snprintf(flags, sizeof(flags), "qhull Qs QJ%G C-0 Pp W1e-14 E1.0e-18",random_eps); // "qhull QbB Pp"
 	if (qhull_free_flag)	  qh_freeqhull(!qh_ALL);                   /* free long memory  */
@@ -604,18 +606,18 @@ IVP_Compact_Ledge *IVP_SurfaceBuilder_Pointsoup::convert_pointsoup_to_compact_le
 	P_FREE(use_list);
     }
     if (!res){
-      IVP_IFDEBUG(IVP_DM_SURBUILD_POINTSOUP) {
+      IVP_IFDEBUG(IVP_DM_SURBUILD_POINTSOUP, {
 	ivp_debugmanager.dprint(IVP_DM_SURBUILD_POINTSOUP, "*** IVP_SurfaceBuilder_Pointsoup::convert_pointsoup_to_template_polygon - couldn't build convex hull! Skipping object...\n");
 	int i;
 	for (i=0; i<points.len(); i++) {
 	  //points->element_at(i)->print();
 	}
-      }
+      })
 
     }
-    IVP_IFDEBUG(IVP_DM_SURBUILD_POINTSOUP) {
+    IVP_IFDEBUG(IVP_DM_SURBUILD_POINTSOUP, {
       ivp_debugmanager.dprint(IVP_DM_SURBUILD_POINTSOUP, "*** Done with convex pointsoup.\n\n");
-    }
+    })
     return res;
 }
 
@@ -723,9 +725,9 @@ IVP_Compact_Surface *IVP_SurfaceBuilder_Pointsoup::convert_pointsoup_to_compact_
     }
     else {
 	IVP_IF(1) {
-	    IVP_IFDEBUG(IVP_DM_SURBUILD_POINTSOUP) {
+	    IVP_IFDEBUG(IVP_DM_SURBUILD_POINTSOUP, {
 		ivp_debugmanager.dprint(IVP_DM_SURBUILD_POINTSOUP, "*** IVP_SurfaceBuilder_Pointsoup::convert_pointsoup_to_compact_surface - skipping ledge due to invalid topology\n");
-	    }
+	    })
 	}
     }
 

--- a/ivp_compact_builder/ivp_surbuild_q12.cxx
+++ b/ivp_compact_builder/ivp_surbuild_q12.cxx
@@ -447,9 +447,9 @@ void IVP_SurfaceBuilder_Q12::convert_model(int model)
 }
 
 
-void IVP_SurfaceBuilder_Q12::convert_node(intp node)
+void IVP_SurfaceBuilder_Q12::convert_node(hk_intp node)
 {
-    this->nodes.add((intp *)node);
+    this->nodes.add((hk_intp *)node);
 
     if ( dnodes[node].children[0] > 0 ) {
 	this->convert_node(dnodes[node].children[0]);
@@ -564,9 +564,9 @@ void IVP_SurfaceBuilder_Q12::nodes_to_planes()
     int i;
     
     for (i=0; i<this->nodes.len(); i++) {
-	dplane_t *bsp_plane = &dplanes[dnodes[(intp)nodes.element_at(i)].planenum];
+	dplane_t *bsp_plane = &dplanes[dnodes[(hk_intp)nodes.element_at(i)].planenum];
 	if ( i == this->nodes.len()-1 ) {
-	    if ( dnodes[(intp)this->nodes.element_at(i)].children[0] == -1 ) {
+	    if ( dnodes[(hk_intp)this->nodes.element_at(i)].children[0] == -1 ) {
 		create_and_insert_plane( bsp_plane->normal[0],  bsp_plane->normal[1],  bsp_plane->normal[2], bsp_plane->dist);
 	    }
 	    else {
@@ -574,7 +574,7 @@ void IVP_SurfaceBuilder_Q12::nodes_to_planes()
 	    }
 	}
 	else {
-	    if ( dnodes[(intp)this->nodes.element_at(i)].children[0] == (intp)this->nodes.element_at(i+1) ) {
+	    if ( dnodes[(hk_intp)this->nodes.element_at(i)].children[0] == (hk_intp)this->nodes.element_at(i+1) ) {
 		create_and_insert_plane( bsp_plane->normal[0],  bsp_plane->normal[1],  bsp_plane->normal[2], bsp_plane->dist);
 	    }
 	    else {

--- a/ivp_compact_builder/ivp_surbuild_q12.hxx
+++ b/ivp_compact_builder/ivp_surbuild_q12.hxx
@@ -36,7 +36,7 @@ typedef struct
 {
     IVP_FLOAT		mins[3], maxs[3];
     IVP_FLOAT		origin[3];
-    intp		headnode[MAX_MAP_HULLS];
+    hk_intp		headnode[MAX_MAP_HULLS];
     int			visleafs;		// not including the solid leaf 0
     int			firstface, numfaces;
 } dmodel_t;
@@ -129,7 +129,7 @@ private:
 
     IVP_U_Vector<IVP_Compact_Ledge> *ledges;
 
-    IVP_U_Vector<intp>         nodes;
+    IVP_U_Vector<hk_intp>         nodes;
     IVP_Halfspacesoup			  *halfspaces;
     
     void cleanup();
@@ -141,7 +141,7 @@ private:
     //void convert_solid_clipnode();       // not used right now, but don't delete!
 
     void nodes_to_planes();
-    void convert_node(intp node);
+    void convert_node(hk_intp node);
     void convert_solid_node();
 
     void convert_model(int model);

--- a/ivp_compact_builder/ivp_tetra_intrude.cxx
+++ b/ivp_compact_builder/ivp_tetra_intrude.cxx
@@ -75,7 +75,7 @@ void IVP_Intrusion_Intersection::print(const char *text){
     if (!text){
 	text = "";
     }else{
-	if ( intp(pairing_intersection) > intp(this)) return;
+	if ( hk_intp(pairing_intersection) > hk_intp(this)) return;
     }
     ivp_message("%s %s Intersection pnt %i - %i",text,
 	   (type != IVP_INTRUSION_CHECK_OVERLAP)? "normal":"equalp",
@@ -263,7 +263,7 @@ void IVP_Tetra_Intrude::checkin_edge(IVP_Tri_Edge *edge){
 
 	this->init_tetra_edge(t_edge,edge->tmp.gen.tetra_point,edge->next->tmp.gen.tetra_point,edge);
     }else{
-	t_edge = (IVP_Tetra_Edge *)(te + intp(tetra_edges));
+	t_edge = (IVP_Tetra_Edge *)(te + hk_intp(tetra_edges));
     }
     t_edge->reference_count++;
     edge->tmp.gen.checked_in = IVP_TRUE;
@@ -285,7 +285,7 @@ void IVP_Tetra_Intrude::checkout_edge(IVP_Tri_Edge *edge){
     }
 
     te = (char *)twop_2_tetra_edge_hash->find((char *)&buffer[0]);
-    t_edge = (IVP_Tetra_Edge *)(te + intp(tetra_edges));
+    t_edge = (IVP_Tetra_Edge *)(te + hk_intp(tetra_edges));
     t_edge->reference_count--;
     /* edge no more referenced -> delete it */
     if (t_edge->reference_count<=0){

--- a/ivp_compact_builder/ivv_cluster_min_hash.hxx
+++ b/ivp_compact_builder/ivv_cluster_min_hash.hxx
@@ -7,7 +7,7 @@ union IVV_Cluster_Min_Hash_Key {
 	unsigned int s1:16;
 	unsigned int s2:16;
     } spheres;
-    uintp key;
+    hk_uintp key;
 };
 
 

--- a/ivp_controller/ivp_actuator.hxx
+++ b/ivp_controller/ivp_actuator.hxx
@@ -276,6 +276,7 @@ public:
     virtual void anchor_will_be_deleted_event(IVP_Anchor *del_anchor); // when an object is deleted it sends events to its connected actuators
     void core_is_going_to_be_deleted_event(IVP_Core *my_core) override;
     virtual ~IVP_Actuator();
+	virtual const char* get_controller_name() override { return "ivp:actuator"; };
 };
 
 

--- a/ivp_controller/ivp_constraint.hxx
+++ b/ivp_controller/ivp_constraint.hxx
@@ -89,6 +89,8 @@ public:
     // constraint changing functions that explain differences
     virtual void change_Aos_to_relaxe_constraint();
     virtual void change_Ros_to_relaxe_constraint();
+
+	virtual const char* get_controller_name() override { return "ivp:constraint"; };
     
     // some functions are missing yet.
 public:

--- a/ivp_controller/ivp_constraint_car.hxx
+++ b/ivp_controller/ivp_constraint_car.hxx
@@ -67,6 +67,8 @@ public:
 	IVP_U_Vector<IVP_Core>	*get_associated_controlled_cores() override		{ return &cores_of_constraint_system; }
     int						get_num_of_appending_terminals()		{ return wheel_objects.len(); }			// e.g. 4 for four wheels, might be more flexible in the future
 
+	virtual const char* get_controller_name() override { return "ivp:constraint_solver_car"; };
+
 public:
     
     friend class IVP_Constraint_Solver_Car_Builder;

--- a/ivp_controller/ivp_constraint_fixed_keyed.hxx
+++ b/ivp_controller/ivp_constraint_fixed_keyed.hxx
@@ -52,6 +52,7 @@ protected:
     IVP_DOUBLE get_minimum_simulation_frequency() override;
     IVP_U_Vector<IVP_Core> *get_associated_controlled_cores() override { return &cores_of_constraint_system; };
     IVP_CONTROLLER_PRIORITY get_controller_priority() override { return IVP_CP_CONSTRAINTS; }
+	virtual const char* get_controller_name() override { return "ivp:template_constraint_fixed_keyframed"; };
 	void ensure_in_simulation();
 	void do_simulation_controller(IVP_Event_Sim *,IVP_U_Vector<IVP_Core> *) override;
 public:

--- a/ivp_controller/ivp_controller.hxx
+++ b/ivp_controller/ivp_controller.hxx
@@ -124,18 +124,19 @@ public:
      ********************************************************************************/
     virtual IVP_CONTROLLER_PRIORITY get_controller_priority() = 0;
 
-    virtual const char* get_controller_name() { return "sys:unknown"; }
+    virtual const char* get_controller_name() { return "sys:unknown"; };
 
     virtual ~IVP_Controller() {}
 };
 
 class IVP_Controller_Independent: public IVP_Controller {
     static IVP_U_Vector<IVP_Core> empty_list;
-    IVP_U_Vector<IVP_Core> *get_associated_controlled_cores() override { return &empty_list; }
+    IVP_U_Vector<IVP_Core> *get_associated_controlled_cores() override { return &empty_list; };
+	virtual const char* get_controller_name() override { return "sys:unknown-independent"; };
 };
 
 class IVP_Controller_Dependent: public IVP_Controller {
-    
+    virtual const char* get_controller_name() override { return "sys:unknown-dependent"; };
 };
 
 
@@ -150,6 +151,7 @@ public:
     IVP_CONTROLLER_PRIORITY get_controller_priority() override { return IVP_CP_GRAVITY; }
     virtual ~IVP_Standard_Gravity_Controller() {}
     void core_is_going_to_be_deleted_event(IVP_Core *) override {}
+	virtual const char* get_controller_name() override { return "ivp:standard_gravity_controller"; }
 };
 
 

--- a/ivp_controller/ivp_controller_airboat.h
+++ b/ivp_controller/ivp_controller_airboat.h
@@ -200,6 +200,8 @@ public:
 	void							SetCarSystemDebugData( const IVP_CarSystemDebugData_t &carSystemDebugData ) override;
 	void							GetCarSystemDebugData( IVP_CarSystemDebugData_t &carSystemDebugData ) override;
 
+	virtual const char* get_controller_name() override { return "ivp:controller_raycast_airboat"; };
+
 protected:
 
     IVP_Real_Object					*m_pAirboatBody;			// *car_body

--- a/ivp_controller/ivp_controller_buoyancy.hxx
+++ b/ivp_controller/ivp_controller_buoyancy.hxx
@@ -264,6 +264,7 @@ protected:
     void core_is_going_to_be_deleted_event(IVP_Core *) override { delete this; }
     IVP_DOUBLE get_minimum_simulation_frequency() override { return 0.0f; }
     IVP_CONTROLLER_PRIORITY get_controller_priority() override { return IVP_CP_FORCEFIELDS; }
+	virtual const char* get_controller_name() override { return "ivp:controller_buoyancy"; };
     
     /********************************************************************
      * Name:        do_simulation_controller(...)

--- a/ivp_controller/ivp_controller_fake_jetski.cpp
+++ b/ivp_controller/ivp_controller_fake_jetski.cpp
@@ -20,7 +20,9 @@
 #include <ivp_controller_raycast_car.hxx>
 #include <ivp_solver_core_reaction.hxx>
 
+#ifdef WIN32
 #include <windows.h>
+#endif
 
 //-----------------------------------------------------------------------------
 // Purpose: Main raycast jetski simulation.
@@ -396,7 +398,11 @@ IVP_DOUBLE IVP_Controller_Raycast_Fake_Jetski::GetSteeringForceRotational( int i
 
 	char szDebug[128];
 	sprintf( szDebug, "RotSpeed %f (%f %f %f)\n",pCarCore->rot_speed.real_length(), pCarCore->rot_speed.k[0], pCarCore->rot_speed.k[1], pCarCore->rot_speed.k[2] );
-	OutputDebugString( szDebug );
+#ifdef WIN32
+	OutputDebugStringA(szDebug);
+#else
+	fprintf(stderr, "%s", szDebug);
+#endif
 
 	// If we are at the speed where we rotate independently of movement direction.
 	

--- a/ivp_controller/ivp_controller_fake_jetski.cpp
+++ b/ivp_controller/ivp_controller_fake_jetski.cpp
@@ -20,10 +20,6 @@
 #include <ivp_controller_raycast_car.hxx>
 #include <ivp_solver_core_reaction.hxx>
 
-#ifdef WIN32
-#include <windows.h>
-#endif
-
 //-----------------------------------------------------------------------------
 // Purpose: Main raycast jetski simulation.
 //-----------------------------------------------------------------------------
@@ -398,11 +394,7 @@ IVP_DOUBLE IVP_Controller_Raycast_Fake_Jetski::GetSteeringForceRotational( int i
 
 	char szDebug[128];
 	sprintf( szDebug, "RotSpeed %f (%f %f %f)\n",pCarCore->rot_speed.real_length(), pCarCore->rot_speed.k[0], pCarCore->rot_speed.k[1], pCarCore->rot_speed.k[2] );
-#ifdef WIN32
-	OutputDebugStringA(szDebug);
-#else
-	fprintf(stderr, "%s", szDebug);
-#endif
+	ivp_message( szDebug );
 
 	// If we are at the speed where we rotate independently of movement direction.
 	

--- a/ivp_controller/ivp_controller_fake_jetski.h
+++ b/ivp_controller/ivp_controller_fake_jetski.h
@@ -165,6 +165,8 @@ public:
 	void							SetCarSystemDebugData( const IVP_CarSystemDebugData_t &carSystemDebugData );
 	void							GetCarSystemDebugData( IVP_CarSystemDebugData_t &carSystemDebugData );
 
+	virtual const char* get_controller_name() override { return "ivp:controller_raycast_fake_jetski"; };
+
 protected:
 
 	// Jetski body.

--- a/ivp_controller/ivp_controller_floating.hxx
+++ b/ivp_controller/ivp_controller_floating.hxx
@@ -53,6 +53,7 @@ protected:
     void do_simulation_controller( IVP_Event_Sim *, IVP_U_Vector<IVP_Core> *core_list ) override;
     IVP_CONTROLLER_PRIORITY get_controller_priority() override { return IVP_CP_FLOATING; }
     void core_is_going_to_be_deleted_event( IVP_Core *core ) override;
+	virtual const char* get_controller_name() override { return "ivp:controller_floating"; };
 
     friend class IVP_Environment;    
 

--- a/ivp_controller/ivp_controller_golem.hxx
+++ b/ivp_controller/ivp_controller_golem.hxx
@@ -54,6 +54,7 @@ protected:
 
     void reset_time( IVP_Time offset) override;
     void do_simulation_controller(IVP_Event_Sim *,IVP_U_Vector<IVP_Core> *) override;
+	virtual const char* get_controller_name() override { return "ivp:controller_golem"; };
 
     void beam_object_to_target_position(IVP_Event_Sim *es);  // may be called from resolve_for_problem to beam object
 public:

--- a/ivp_controller/ivp_controller_motion.hxx
+++ b/ivp_controller/ivp_controller_motion.hxx
@@ -57,6 +57,7 @@ protected:
     
     IVP_CONTROLLER_PRIORITY get_controller_priority() override { return IVP_CP_MOTION; }
     void core_is_going_to_be_deleted_event(IVP_Core *core) override;
+	virtual const char* get_controller_name() override { return "ivp:controller_motion"; };
 
     friend class IVP_Environment;
 public:

--- a/ivp_controller/ivp_controller_raycast_car.hxx
+++ b/ivp_controller/ivp_controller_raycast_car.hxx
@@ -202,6 +202,8 @@ public:
 	// Debug
 	void SetCarSystemDebugData( const IVP_CarSystemDebugData_t &carSystemDebugData ) override;
 	void GetCarSystemDebugData( IVP_CarSystemDebugData_t &carSystemDebugData ) override;
+
+	virtual const char* get_controller_name() override { return "ivp:controller_raycast_car"; };
 };
 
 #endif

--- a/ivp_controller/ivp_controller_world_frict.hxx
+++ b/ivp_controller/ivp_controller_world_frict.hxx
@@ -31,6 +31,7 @@ protected:
     
     IVP_CONTROLLER_PRIORITY get_controller_priority() override { return IVP_CP_CONSTRAINTS_MAX; }
     void core_is_going_to_be_deleted_event(IVP_Core *core) override;
+	virtual const char* get_controller_name() override { return "ivp:controller_world_friction"; };
 
     friend class IVP_Environment;    
     

--- a/ivp_controller/ivp_forcefield.hxx
+++ b/ivp_controller/ivp_forcefield.hxx
@@ -36,7 +36,8 @@ protected:
 
     // IVP_Controller implementations (only some)
     void core_is_going_to_be_deleted_event(IVP_Core *) override;   // default deletes this
-    
+    virtual const char* get_controller_name() override { return "ivp:forcefield"; };
+
     virtual void do_simulation_controller(IVP_Event_Sim *,IVP_U_Vector<IVP_Core> *core_list)=0;
     IVP_CONTROLLER_PRIORITY get_controller_priority() override;
     IVP_Forcefield(IVP_Environment *env, IVP_U_Set_Active<IVP_Core> *set_of_cores, IVP_BOOL owner_of_set);

--- a/ivp_intern/ivp_calc_next_psi_solver.cxx
+++ b/ivp_intern/ivp_calc_next_psi_solver.cxx
@@ -157,12 +157,12 @@ no_sim_speedup:
 /* needs speed rot_speed  next_psi_time */
 void IVP_Calc_Next_PSI_Solver::calc_next_PSI_matrix(IVP_Event_Sim *event_sim,IVP_U_Vector<IVP_Hull_Manager_Base> *active_hull_managers_out){
    
-   IVP_IF(1) {
+   IVP_IFDEBUG(1,
         IVP_Debug_Manager *dm=event_sim->environment->get_debug_manager();
-	if(dm->file_out_impacts) {
-	    fprintf(dm->out_deb_file,"making_calc_next_psi %zi at %f\n",0x0000ffff&(hk_intp)this,core->environment->get_current_time().get_time());
-	}
-    }    
+		if(dm->file_out_impacts) {
+			fprintf(dm->out_deb_file,"making_calc_next_psi %zi at %f\n",0x0000ffff&(hk_intp)this,core->environment->get_current_time().get_time());
+		}
+	) 
 
    if (!( core->car_wheel && (core->max_surface_deviation == 0.0f) )) { //@@CB
 		core->clip_velocity(&core->speed, &core->rot_speed);

--- a/ivp_intern/ivp_calc_next_psi_solver.cxx
+++ b/ivp_intern/ivp_calc_next_psi_solver.cxx
@@ -160,7 +160,7 @@ void IVP_Calc_Next_PSI_Solver::calc_next_PSI_matrix(IVP_Event_Sim *event_sim,IVP
    IVP_IF(1) {
         IVP_Debug_Manager *dm=event_sim->environment->get_debug_manager();
 	if(dm->file_out_impacts) {
-	    fprintf(dm->out_deb_file,"making_calc_next_psi %zi at %f\n",0x0000ffff&(intp)this,core->environment->get_current_time().get_time());
+	    fprintf(dm->out_deb_file,"making_calc_next_psi %zi at %f\n",0x0000ffff&(hk_intp)this,core->environment->get_current_time().get_time());
 	}
     }    
 

--- a/ivp_intern/ivp_calc_next_psi_solver.cxx
+++ b/ivp_intern/ivp_calc_next_psi_solver.cxx
@@ -157,7 +157,7 @@ no_sim_speedup:
 /* needs speed rot_speed  next_psi_time */
 void IVP_Calc_Next_PSI_Solver::calc_next_PSI_matrix(IVP_Event_Sim *event_sim,IVP_U_Vector<IVP_Hull_Manager_Base> *active_hull_managers_out){
    
-   IVP_IFDEBUG(1,
+   IVP_IFDEBUG(IVP_TRUE,
         IVP_Debug_Manager *dm=event_sim->environment->get_debug_manager();
 		if(dm->file_out_impacts) {
 			fprintf(dm->out_deb_file,"making_calc_next_psi %zi at %f\n",0x0000ffff&(hk_intp)this,core->environment->get_current_time().get_time());

--- a/ivp_intern/ivp_controller_phantom.cxx
+++ b/ivp_intern/ivp_controller_phantom.cxx
@@ -128,7 +128,7 @@ void IVP_Controller_Phantom::mindist_entered_volume(class IVP_Mindist *mindist)
 		{
 			other_object = mindist->get_synapse(0)->get_object();
 		}
-        intp x = (intp)mindist_object_counter->find_elem( other_object );
+        hk_intp x = (hk_intp)mindist_object_counter->find_elem( other_object );
 		if (x)
 		{
 			mindist_object_counter->change_elem( other_object, (void *)(x+1));
@@ -151,7 +151,7 @@ void IVP_Controller_Phantom::mindist_entered_volume(class IVP_Mindist *mindist)
 			other_object = mindist->get_synapse(0)->get_object();
 		}
 		IVP_Core *other_core= other_object->get_core();
-        intp x = (intp)mindist_core_counter->find_elem( other_core );
+        hk_intp x = (hk_intp)mindist_core_counter->find_elem( other_core );
 		if (x)
 		{
 			mindist_core_counter->change_elem( other_core, (void *)(x+1));
@@ -188,7 +188,7 @@ void IVP_Controller_Phantom:: mindist_left_volume(class IVP_Mindist *mindist)
 		{
 			other_object = mindist->get_synapse(0)->get_object();
 		}
-        intp x = (intp)mindist_object_counter->find_elem( other_object );
+        hk_intp x = (hk_intp)mindist_object_counter->find_elem( other_object );
 		if (x>1)
 		{
 			mindist_object_counter->change_elem( other_object, (void *)(x-1));
@@ -211,7 +211,7 @@ void IVP_Controller_Phantom:: mindist_left_volume(class IVP_Mindist *mindist)
 			other_object = mindist->get_synapse(0)->get_object();
 		}
 		IVP_Core *other_core= other_object->get_core();
-        intp x = (intp)mindist_core_counter->find_elem( other_core );
+        hk_intp x = (hk_intp)mindist_core_counter->find_elem( other_core );
 		if (x>1)
 		{
 			mindist_core_counter->change_elem( other_core, (void *)(x-1));

--- a/ivp_intern/ivp_core.cxx
+++ b/ivp_intern/ivp_core.cxx
@@ -770,7 +770,7 @@ void IVP_Core::synchronize_with_rot_z(){
     IVP_IF(1) {
         IVP_Debug_Manager *dm=environment->get_debug_manager();
 	if(dm->file_out_impacts) {
-	    fprintf(dm->out_deb_file,"doing_synchronize %zi at %f\n",0x0000ffff&(intp)this,current_time.get_time());
+	    fprintf(dm->out_deb_file,"doing_synchronize %zi at %f\n",0x0000ffff&(hk_intp)this,current_time.get_time());
 	}
     }
     
@@ -801,7 +801,7 @@ void IVP_Core::undo_synchronize_rot_z() {
     IVP_IF(1) {
         IVP_Debug_Manager *dm=environment->get_debug_manager();
 	if(dm->file_out_impacts) {
-	    fprintf(dm->out_deb_file,"undoing_synchro %x at %f\n",0x0000ffff&(IVP_INT32)(intp)this,environment->get_current_time().get_time());
+	    fprintf(dm->out_deb_file,"undoing_synchro %x at %f\n",0x0000ffff&(IVP_INT32)(hk_intp)this,environment->get_current_time().get_time());
 	}
     }
     rot_speed.      set(&tmp_null.old_sync_info->old_sync_rot_speed);

--- a/ivp_intern/ivp_core.cxx
+++ b/ivp_intern/ivp_core.cxx
@@ -767,12 +767,12 @@ void IVP_Core::synchronize_with_rot_z(){
     
     IVP_Time current_time = environment->get_current_time();
 
-    IVP_IF(1) {
+    IVP_IFDEBUG(1,
         IVP_Debug_Manager *dm=environment->get_debug_manager();
-	if(dm->file_out_impacts) {
-	    fprintf(dm->out_deb_file,"doing_synchronize %zi at %f\n",0x0000ffff&(hk_intp)this,current_time.get_time());
-	}
-    }
+		if(dm->file_out_impacts) {
+			fprintf(dm->out_deb_file,"doing_synchronize %zi at %f\n",0x0000ffff&(hk_intp)this,current_time.get_time());
+		}
+	)
     
     tmp_null.old_sync_info->old_sync_rot_speed. set(&rot_speed);
     tmp_null.old_sync_info->old_sync_q_world_f_core_next_psi = q_world_f_core_next_psi;
@@ -798,12 +798,12 @@ void IVP_Core::synchronize_with_rot_z(){
  * undos synchronize_with_rot_z (only if not calc_next_PSI_matrix is not called
  **************************/
 void IVP_Core::undo_synchronize_rot_z() {    
-    IVP_IF(1) {
+    IVP_IFDEBUG(1,
         IVP_Debug_Manager *dm=environment->get_debug_manager();
-	if(dm->file_out_impacts) {
-	    fprintf(dm->out_deb_file,"undoing_synchro %x at %f\n",0x0000ffff&(IVP_INT32)(hk_intp)this,environment->get_current_time().get_time());
-	}
-    }
+		if(dm->file_out_impacts) {
+			fprintf(dm->out_deb_file,"undoing_synchro %x at %f\n",0x0000ffff&(IVP_INT32)(hk_intp)this,environment->get_current_time().get_time());
+		}
+	)
     rot_speed.      set(&tmp_null.old_sync_info->old_sync_rot_speed);
     q_world_f_core_next_psi = tmp_null.old_sync_info->old_sync_q_world_f_core_next_psi;
     tmp_null.old_sync_info=NULL;
@@ -1213,20 +1213,20 @@ IVP_Friction_Info_For_Core *IVP_Core::get_friction_info(IVP_Friction_System *my_
 	    IVP_Friction_Info_For_Core *fr_info;
 	    fr_info=my_hash->find_friction_info( my_fr_system );
 #ifdef DEBUG_FRICTION_CONSISTENCY
-	    IVP_IF( my_fr_system->l_environment->get_debug_manager()->check_fs ) {
-	    IVP_Friction_Info_For_Core *test_info;
-		test_info=NULL;
-		int i;
-		for(i=0;i<list_debug_hash.len();i++) {
-		    IVP_Friction_Info_For_Core *search;
-		    search=list_debug_hash.element_at(i);
-		    if(search->l_friction_system == my_fr_system) {
-			test_info=search;
-			break;
-		    }
-		}
-		IVP_ASSERT( test_info == fr_info );
-	    }
+	    IVP_IFDEBUG( my_fr_system->l_environment->get_debug_manager()->check_fs,
+			IVP_Friction_Info_For_Core *test_info;
+			test_info=NULL;
+			int i;
+			for(i=0;i<list_debug_hash.len();i++) {
+				IVP_Friction_Info_For_Core *search;
+				search=list_debug_hash.element_at(i);
+				if(search->l_friction_system == my_fr_system) {
+				test_info=search;
+				break;
+				}
+			}
+			IVP_ASSERT( test_info == fr_info );
+		)
 #endif
 	    return fr_info;
 	} else {
@@ -1260,9 +1260,9 @@ void IVP_Core::add_friction_info(IVP_Friction_Info_For_Core *my_fr_info)
 	}
 	this->core_friction_info.for_unmoveables.l_friction_info_hash->add_friction_info( my_fr_info );
 #ifdef DEBUG_FRICTION_CONSISTENCY
-	IVP_IF(environment->get_debug_manager()->check_fs) {
+	IVP_IFDEBUG(environment->get_debug_manager()->check_fs,
 	    this->list_debug_hash.add( my_fr_info );
-	}
+	)
 #endif
     } else {
 	IVP_ASSERT( this->core_friction_info.for_moveables.moveable_core_friction_info == NULL );
@@ -1292,7 +1292,7 @@ void IVP_Core::unlink_friction_info(IVP_Friction_Info_For_Core *my_fr_info)
 	my_info = this->core_friction_info.for_unmoveables.l_friction_info_hash->remove_friction_info( my_fr_info );
 	IVP_ASSERT( my_info );
 #ifdef DEBUG_FRICTION_CONSISTENCY
-	IVP_IF( environment->get_debug_manager()->check_fs ) {
+	IVP_IFDEBUG( environment->get_debug_manager()->check_fs,
 	    int i=0;
 	    IVP_Friction_Info_For_Core*my_test_info=NULL;
 	    while(my_info!=NULL) {
@@ -1305,7 +1305,7 @@ void IVP_Core::unlink_friction_info(IVP_Friction_Info_For_Core *my_fr_info)
 		i++;
 	    }
 	    IVP_ASSERT( my_info==my_test_info );
-	}
+	)
 #endif
     } else {
 	IVP_ASSERT( this->core_friction_info.for_moveables.moveable_core_friction_info == my_fr_info );

--- a/ivp_intern/ivp_core.cxx
+++ b/ivp_intern/ivp_core.cxx
@@ -826,7 +826,7 @@ void IVP_Core::calc_calc(){
     IVP_U_Float_Point &ri = rot_inertia;
     for ( int i = 0; i < 3; i++ )
     {
-        if ( _finite( ri.k[i] ) && ri.k[i] <= 1e18f )
+        if ( std::isfinite( ri.k[i] ) && ri.k[i] <= 1e18f )
         {
             if ( ri.k[i] < -1e18f )
                 ri.k[i] = -1e18f;

--- a/ivp_intern/ivp_core.cxx
+++ b/ivp_intern/ivp_core.cxx
@@ -767,7 +767,7 @@ void IVP_Core::synchronize_with_rot_z(){
     
     IVP_Time current_time = environment->get_current_time();
 
-    IVP_IFDEBUG(1,
+    IVP_IFDEBUG(IVP_TRUE,
         IVP_Debug_Manager *dm=environment->get_debug_manager();
 		if(dm->file_out_impacts) {
 			fprintf(dm->out_deb_file,"doing_synchronize %zi at %f\n",0x0000ffff&(hk_intp)this,current_time.get_time());
@@ -798,7 +798,7 @@ void IVP_Core::synchronize_with_rot_z(){
  * undos synchronize_with_rot_z (only if not calc_next_PSI_matrix is not called
  **************************/
 void IVP_Core::undo_synchronize_rot_z() {    
-    IVP_IFDEBUG(1,
+    IVP_IFDEBUG(IVP_TRUE,
         IVP_Debug_Manager *dm=environment->get_debug_manager();
 		if(dm->file_out_impacts) {
 			fprintf(dm->out_deb_file,"undoing_synchro %x at %f\n",0x0000ffff&(IVP_INT32)(hk_intp)this,environment->get_current_time().get_time());

--- a/ivp_intern/ivp_environment.cxx
+++ b/ivp_intern/ivp_environment.cxx
@@ -882,10 +882,10 @@ void IVP_Environment::simulate_psi(IVP_Time /*psi_time*/){
 	    get_statistic_manager()->last_statistic_output = get_current_time();
 	}
     }
-    IVP_IF(1) {
-	get_debug_manager()->psi_counter += 1.0f;
+    IVP_DEBUGCODE(
+		get_debug_manager()->psi_counter += 1.0f;
         delete_draw_vector_debug();
-    }
+	)
 
 
 #ifdef IVP_ENABLE_PERFORMANCE_COUNTER

--- a/ivp_intern/ivp_friction.cxx
+++ b/ivp_intern/ivp_friction.cxx
@@ -83,13 +83,13 @@ IVP_Contact_Point::IVP_Contact_Point( IVP_Mindist *md)
 
     //this->l_environment = mindist->l_environment;
     IVP_IF(1) {
-	IVP_IF(env->get_debug_manager()->check_fs) {
+	IVP_IFDEBUG(env->get_debug_manager()->check_fs,
 	    fprintf(env->get_debug_manager()->out_deb_file,"create_mindist %f %p cores %p %p\n",
 		    env->get_current_time().get_time(),
 		    this,
 		    syn0->l_obj->physical_core,
 		    syn0->l_obj->physical_core);
-	}
+	)
     }
     if ( syn1->get_status() == IVP_ST_TRIANGLE){
 	const IVP_Compact_Edge *e1 = syn1->edge;
@@ -1037,23 +1037,22 @@ IVP_Contact_Point::~IVP_Contact_Point(){
     }
    {
      IVP_Core *core0 = nullptr,*core1 = nullptr;
-     IVP_BOOL check_fs = env->get_debug_manager()->check_fs;
-        IVP_IF( check_fs ) {
+     IVP_IFDEBUG( env->get_debug_manager()->check_fs,
 	    core0=get_synapse(0)->l_obj->friction_core;
 	    core1=get_synapse(1)->l_obj->friction_core;
-	}
+	)
 	
 	get_synapse(0)->remove_friction_synapse_from_object();
 	get_synapse(1)->remove_friction_synapse_from_object();
 
-	IVP_IF( check_fs ) {
+	IVP_IFDEBUG( env->get_debug_manager()->check_fs,
 	    if(core0->physical_unmoveable) {
 	        core0->unmovable_core_debug_friction_hash();
 	    }
 	    if(core1->physical_unmoveable) {
 	        core1->unmovable_core_debug_friction_hash();
 	    }
-	}
+	)
     }
 }
 
@@ -1190,19 +1189,19 @@ void IVP_Friction_System::fusion_friction_systems(IVP_Friction_System *second_sy
   
     IVP_IF(1) {
         IVP_Environment *env=first_sys->l_environment;
-	IVP_IF(env->get_debug_manager()->check_fs) {
-	    ivp_message("fusion_fs %f %p %p  cores ",env->get_current_time().get_time(),first_sys,second_sys);
-	    for (int k = first_sys->cores_of_friction_system.len()-1; k>=0; k--){
-		IVP_Core *my_core = first_sys->cores_of_friction_system.element_at(k);
-	        ivp_message("%p ",my_core);
-	    }
-	    ivp_message(" ");
-	    for (int l = second_sys->cores_of_friction_system.len()-1; l>=0; l--){
-		IVP_Core *my_core = second_sys->cores_of_friction_system.element_at(l);
-	        ivp_message("%p ",my_core);
-	    }
-	    ivp_message("\n");	    
-	}
+		IVP_IFDEBUG(env->get_debug_manager()->check_fs,
+			ivp_message("fusion_fs %f %p %p  cores ",env->get_current_time().get_time(),first_sys,second_sys);
+			for (int k = first_sys->cores_of_friction_system.len()-1; k>=0; k--){
+			IVP_Core *my_core = first_sys->cores_of_friction_system.element_at(k);
+				ivp_message("%p ",my_core);
+			}
+			ivp_message(" ");
+			for (int l = second_sys->cores_of_friction_system.len()-1; l>=0; l--){
+			IVP_Core *my_core = second_sys->cores_of_friction_system.element_at(l);
+				ivp_message("%p ",my_core);
+			}
+			ivp_message("\n");	    
+		)
     }
   
     IVP_Contact_Point *my_dist,*next_dist;
@@ -1411,14 +1410,14 @@ void IVP_Friction_System::split_friction_system(IVP_Core *split_father)
     
     IVP_Friction_System *new_fr_sys=new IVP_Friction_System(l_environment);
 
-     IVP_IF( fr_sys->l_environment->get_debug_manager()->check_fs ) {
+     IVP_IFDEBUG( fr_sys->l_environment->get_debug_manager()->check_fs,
         ivp_message("split_fs %f %p %p  cores ",fr_sys->l_environment->get_current_time().get_time(),fr_sys,new_fr_sys);
-	for (int i = fr_sys->cores_of_friction_system.len()-1; i>=0;i--){
-	    IVP_Core *my_core = fr_sys->cores_of_friction_system.element_at(i);
-	    ivp_message("%p ",my_core);
-	}
-	ivp_message("\n");
-     }
+		for (int i = fr_sys->cores_of_friction_system.len()-1; i>=0;i--){
+			IVP_Core *my_core = fr_sys->cores_of_friction_system.element_at(i);
+			ivp_message("%p ",my_core);
+		}
+		ivp_message("\n");
+	)
 
     //ivp_message("splitting_now father %lx\n",(long)split_father&0x0000ffff);
     //fr_sys->debug_fs_out_ascii();
@@ -2005,9 +2004,9 @@ inline IVP_FLOAT ivp_minimum(IVP_FLOAT a,IVP_FLOAT b) {
 // returns IVP_TRUE when a friction system has been grown
 IVP_BOOL IVP_Core::grow_friction_system() {
 
-    IVP_IF( environment->get_debug_manager()->check_fs ) {
-	ivp_message("growing_fs %f core %p\n",environment->get_current_time().get_time(),this);
-    }
+    IVP_IFDEBUG( environment->get_debug_manager()->check_fs,
+		ivp_message("growing_fs %f core %p\n",environment->get_current_time().get_time(),this);
+	)
 
     IVP_BOOL grew_new_contact_point=IVP_FALSE;
     

--- a/ivp_intern/ivp_friction.cxx
+++ b/ivp_intern/ivp_friction.cxx
@@ -1374,7 +1374,7 @@ IVP_Core *IVP_Friction_System::union_find_fr_sys()
 	for (int k = fr_sys->cores_of_friction_system.len()-1; k>=0; k--){
 	    IVP_Core *objj = fr_sys->cores_of_friction_system.element_at(k);
 	    IVP_Core *of=objj->union_find_get_father();
-	    ivp_message("uff of %zi : %zi\n",(intp)objj&0x0000ffff,(intp)of&0x0000ffff);
+	    ivp_message("uff of %zi : %zi\n",(hk_intp)objj&0x0000ffff,(hk_intp)of&0x0000ffff);
 	}
     }
 
@@ -1570,19 +1570,19 @@ void IVP_Friction_System::split_friction_system(IVP_Core *split_father)
 void IVP_Friction_System::print_all_dists()
 {
     IVP_IF(1) {
-    ivp_message("fs %zi  ",(intp)this&0x0000ffff);
+    ivp_message("fs %zi  ",(hk_intp)this&0x0000ffff);
 		for(IVP_Contact_Point *mindist=this->get_first_friction_dist();mindist;mindist=this->get_next_friction_dist(mindist))
 		{
-		    ivp_message("%zi ",(intp)mindist&0x0000ffff);
+		    ivp_message("%zi ",(hk_intp)mindist&0x0000ffff);
 		}    
     ivp_message("\n");
     ivp_message("      ");
     for (int i = fr_pairs_of_objs.len()-1; i>=0; i--){
 	IVP_Friction_Core_Pair *fr_pair = fr_pairs_of_objs.element_at(i);
-	ivp_message("p %zi %zi  ",(intp)fr_pair->objs[0]&0x0000ffff,(intp)fr_pair->objs[1]&0x0000ffff);
+	ivp_message("p %zi %zi  ",(hk_intp)fr_pair->objs[0]&0x0000ffff,(hk_intp)fr_pair->objs[1]&0x0000ffff);
 	for (int c = fr_pair->fr_dists.len()-1;c>=0; c--){
 	    IVP_Contact_Point *fr_dist=fr_pair->fr_dists.element_at(c);
-	    ivp_message("%zi ",(intp)fr_dist&0x0000ffff);
+	    ivp_message("%zi ",(hk_intp)fr_dist&0x0000ffff);
 	}
     }
     ivp_message("\n");
@@ -1901,30 +1901,30 @@ void IVP_Friction_Core_Pair::debug_read_vector_after_ease() {
 void IVP_Friction_System::debug_fs_out_ascii()
 {
     IVP_IF(1) {
-    ivp_message("fs %zi  ",(intp)this&0x0000ffff);
+    ivp_message("fs %zi  ",(hk_intp)this&0x0000ffff);
 		for(IVP_Contact_Point *mindist=this->get_first_friction_dist();mindist;mindist=this->get_next_friction_dist(mindist))
 		{
-		    ivp_message("%zi ",(intp)mindist&0x0000ffff);
+		    ivp_message("%zi ",(hk_intp)mindist&0x0000ffff);
 		}    
     ivp_message("\n");
     for (int k = cores_of_friction_system.len()-1; k>=0; k--){
 	IVP_Core *my_core = cores_of_friction_system.element_at(k);
-        ivp_message("    core %zi  ",(intp)my_core&0x0000ffff);
+        ivp_message("    core %zi  ",(hk_intp)my_core&0x0000ffff);
 	IVP_Friction_Info_For_Core *inf=my_core->get_friction_info(this);
-	ivp_message("lfs %zi  ",(intp)inf->l_friction_system&0x0000ffff);
+	ivp_message("lfs %zi  ",(hk_intp)inf->l_friction_system&0x0000ffff);
 
 	for (int i = inf->friction_springs.len()-1; i>=0; i--){
 	    IVP_Contact_Point *mindist = inf->friction_springs.element_at(i);
-	    ivp_message("%zi  ",(intp)mindist&0x0000ffff);
+	    ivp_message("%zi  ",(hk_intp)mindist&0x0000ffff);
 	}
     }
     ivp_message("\n");
     for (int m = fr_pairs_of_objs.len()-1; m>=0;m--){
 	IVP_Friction_Core_Pair *fr_pair = fr_pairs_of_objs.element_at(m);
-	ivp_message("    p %zi %zi  ",(intp)fr_pair->objs[0]&0x0000ffff,(intp)fr_pair->objs[1]&0x0000ffff);
+	ivp_message("    p %zi %zi  ",(hk_intp)fr_pair->objs[0]&0x0000ffff,(hk_intp)fr_pair->objs[1]&0x0000ffff);
 	for (int c = fr_pair->fr_dists.len()-1; c>=0; c--){
 	    IVP_Contact_Point *fr_dist= fr_pair->fr_dists.element_at(c);
-	    ivp_message("%zi ",(intp)fr_dist&0x0000ffff);
+	    ivp_message("%zi ",(hk_intp)fr_dist&0x0000ffff);
 	}
     }
     ivp_message("\n");

--- a/ivp_intern/ivp_friction.hxx
+++ b/ivp_intern/ivp_friction.hxx
@@ -110,8 +110,8 @@ public:
   IVP_Synapse_Friction 	 *next, *prev;		        // per object list
   IVP_Real_Object  *l_obj;				// back link to object
 protected:
-  // dimhotepus: x86-64 - short -> intp
-  intp contact_point_offset;               // back link to my controlling mindist
+  // dimhotepus: x86-64 - short -> hk_intp
+  hk_intp contact_point_offset;               // back link to my controlling mindist
   short status:8;			    // type IVP_SYNAPSE_POLYGON_STATUS  point, edge, tri, ball ....
 public:
     

--- a/ivp_intern/ivp_friction.hxx
+++ b/ivp_intern/ivp_friction.hxx
@@ -448,7 +448,7 @@ public:
     //for debugging
     void debug_clean_tmp_info();
     void debug_check_system_consistency();
-    IVP_DOUBLE sum_energy_destroyed;
+    //IVP_DOUBLE sum_energy_destroyed;
     void test_hole_fr_system_data(); 
     void print_all_dists();
     static int friction_global_counter;

--- a/ivp_intern/ivp_friction.hxx
+++ b/ivp_intern/ivp_friction.hxx
@@ -324,6 +324,7 @@ public:
     virtual ~IVP_Friction_Sys_Energy() {}
     void core_is_going_to_be_deleted_event(IVP_Core *core) override;
     IVP_DOUBLE get_mimumum_simulation_frequency() { return 1.0f; }
+	virtual const char* get_controller_name() override { return "ivp:friction_sys_energy"; };
 };
 
 class IVP_Friction_Sys_Static : public IVP_Controller_Independent {
@@ -338,6 +339,7 @@ public:
     
     void core_is_going_to_be_deleted_event(IVP_Core *del_core) override;
     IVP_DOUBLE get_minimum_simulation_frequency() override { return 1.0f; }
+	virtual const char* get_controller_name() override { return "ivp:friction_sys_static"; };
 };
 
 // a physical unmovable object can have more than one friction system and for every friction systems several distances
@@ -454,6 +456,7 @@ public:
     void debug_fs_out_ascii();
     void ivp_debug_fs_pointers();
     void debug_fs_after_complex();
+	virtual const char* get_controller_name() override { return "ivp:friction_system"; };
 };
 
 class IVP_Mutual_Energizer {

--- a/ivp_intern/ivp_friction_gaps.cxx
+++ b/ivp_intern/ivp_friction_gaps.cxx
@@ -641,7 +641,7 @@ void IVP_Friction_System::test_hole_fr_system_data()
 			temp_dist=fs->get_next_friction_dist(temp_dist);
 		    }
 		    if(!is_in_collection){
-			ivp_message("test_fr there was mindist %zi in obj which is not in system\n",(intp)all_dists&0x0000ffff); CORE; 
+			ivp_message("test_fr there was mindist %zi in obj which is not in system\n",(hk_intp)all_dists&0x0000ffff); CORE; 
 		    }
 		}
 	    }
@@ -1009,10 +1009,10 @@ void IVP_Friction_System::exchange_friction_dists(IVP_Contact_Point *first_frd,I
 void IVP_Friction_System::ivp_debug_fs_pointers()
 {
     IVP_IF(1) {
-    ivp_message("%zi  ",(intp)first_friction_dist&0x0000ffff);
+    ivp_message("%zi  ",(hk_intp)first_friction_dist&0x0000ffff);
     for(IVP_Contact_Point *fr_d=get_first_friction_dist();fr_d;fr_d=get_next_friction_dist(fr_d))
     {
-	ivp_message("%zi %zi %d %zi  ",(intp)fr_d->prev_dist_in_friction&0x0000ffff,(intp)fr_d&0x0000ffff,fr_d->has_negative_pull_since,(intp)fr_d->next_dist_in_friction&0x0000ffff);
+	ivp_message("%zi %zi %d %zi  ",(hk_intp)fr_d->prev_dist_in_friction&0x0000ffff,(hk_intp)fr_d&0x0000ffff,fr_d->has_negative_pull_since,(hk_intp)fr_d->next_dist_in_friction&0x0000ffff);
     }
     ivp_message("\n");
     }

--- a/ivp_intern/ivp_great_matrix.cxx
+++ b/ivp_intern/ivp_great_matrix.cxx
@@ -22,9 +22,9 @@
 inline void IVP_VecFPU::fpu_add_multiple_row(IVP_DOUBLE *target_adress,IVP_DOUBLE *source_adress,IVP_DOUBLE factor,int size,IVP_BOOL adress_aligned) {
     if(adress_aligned==IVP_FALSE) {
 	//we have to calculate the block size and shift adresses to lower aligned adresses
-	intp result_adress = intp(source_adress) & IVP_VECFPU_MEM_MASK;
-	target_adress = (IVP_DOUBLE *)( intp (target_adress) & IVP_VECFPU_MEM_MASK);
-	size += (intp(source_adress)-result_adress)>>IVP_VECFPU_MEMSHIFT;
+	hk_intp result_adress = hk_intp(source_adress) & IVP_VECFPU_MEM_MASK;
+	target_adress = (IVP_DOUBLE *)( hk_intp (target_adress) & IVP_VECFPU_MEM_MASK);
+	size += (hk_intp(source_adress)-result_adress)>>IVP_VECFPU_MEMSHIFT;
 	source_adress=(IVP_DOUBLE *)result_adress;
     }
 
@@ -103,9 +103,9 @@ inline void IVP_VecFPU::fpu_add_multiple_row(IVP_DOUBLE *target_adress,IVP_DOUBL
 inline IVP_DOUBLE IVP_VecFPU::fpu_large_dot_product(IVP_DOUBLE *base_a, IVP_DOUBLE *base_b, int size, IVP_BOOL adress_aligned) {
     if(adress_aligned==IVP_FALSE) {
 	    //we have to calculate the block size and shift adresses to lower aligned adresses
-	    intp result_adress = intp(base_a) & IVP_VECFPU_MEM_MASK;
-	    base_b = (IVP_DOUBLE *)( intp (base_b) & IVP_VECFPU_MEM_MASK);
-	    size += (intp(base_a)-result_adress)>>IVP_VECFPU_MEMSHIFT;  // because start changed
+	    hk_intp result_adress = hk_intp(base_a) & IVP_VECFPU_MEM_MASK;
+	    base_b = (IVP_DOUBLE *)( hk_intp (base_b) & IVP_VECFPU_MEM_MASK);
+	    size += (hk_intp(base_a)-result_adress)>>IVP_VECFPU_MEMSHIFT;  // because start changed
 	    base_a=(IVP_DOUBLE *)result_adress;
     }
 #   if defined(IVP_WILLAMETTE)
@@ -159,8 +159,8 @@ inline IVP_DOUBLE IVP_VecFPU::fpu_large_dot_product(IVP_DOUBLE *base_a, IVP_DOUB
 inline void IVP_VecFPU::fpu_multiply_row(IVP_DOUBLE *target_adress,IVP_DOUBLE factor,int size,IVP_BOOL adress_aligned) {
     if(adress_aligned==IVP_FALSE) {
 	//we have to calculate the block size and shift adresses to lower aligned adresses
-	intp adress,result_adress;
-	adress=(intp)target_adress;
+	hk_intp adress,result_adress;
+	adress=(hk_intp)target_adress;
 	result_adress=adress & IVP_VECFPU_MEM_MASK;
 	size+=(adress-result_adress)>>IVP_VECFPU_MEMSHIFT;
 	target_adress=(IVP_DOUBLE *)result_adress;
@@ -206,12 +206,12 @@ inline void IVP_VecFPU::fpu_multiply_row(IVP_DOUBLE *target_adress,IVP_DOUBLE fa
 inline void IVP_VecFPU::fpu_exchange_rows(IVP_DOUBLE *target_adress1,IVP_DOUBLE *target_adress2,int size,IVP_BOOL adress_aligned) {
     if(adress_aligned==IVP_FALSE) {
 	//we have to calculate the block size and shift adresses to lower aligned adresses
-	intp adress,result_adress;
-	adress=(intp)target_adress1;
+	hk_intp adress,result_adress;
+	adress=(hk_intp)target_adress1;
 	result_adress=adress & IVP_VECFPU_MEM_MASK;
 	size+=(adress-result_adress)>>IVP_VECFPU_MEMSHIFT;
 	target_adress1=(IVP_DOUBLE *)result_adress;
-	adress=(intp)target_adress2;
+	adress=(hk_intp)target_adress2;
 	adress=adress & IVP_VECFPU_MEM_MASK;
 	target_adress2=(IVP_DOUBLE *)adress;
     }
@@ -253,12 +253,12 @@ inline void IVP_VecFPU::fpu_exchange_rows(IVP_DOUBLE *target_adress1,IVP_DOUBLE 
 inline void IVP_VecFPU::fpu_copy_rows(IVP_DOUBLE *target_adress,IVP_DOUBLE *source_adress,int size,IVP_BOOL adress_aligned) {
     if(adress_aligned==IVP_FALSE) {
 	//we have to calculate the block size and shift adresses to lower aligned adresses
-	intp adress,result_adress;
-	adress=(intp)source_adress;
+	hk_intp adress,result_adress;
+	adress=(hk_intp)source_adress;
 	result_adress=adress & IVP_VECFPU_MEM_MASK;
 	size+=(adress-result_adress)>>IVP_VECFPU_MEMSHIFT;
 	source_adress=(IVP_DOUBLE *)result_adress;
-	adress=(intp)target_adress;
+	adress=(hk_intp)target_adress;
 	adress=adress & IVP_VECFPU_MEM_MASK;
 	target_adress=(IVP_DOUBLE *)adress;
     }
@@ -288,8 +288,8 @@ inline void IVP_VecFPU::fpu_copy_rows(IVP_DOUBLE *target_adress,IVP_DOUBLE *sour
 
 inline void IVP_VecFPU::fpu_set_row_to_zero(IVP_DOUBLE *target_adress,int size,IVP_BOOL adress_aligned) {
     if(adress_aligned==IVP_FALSE) {
-        intp adress,result_adress;
-	adress=(intp)target_adress;
+        hk_intp adress,result_adress;
+	adress=(hk_intp)target_adress;
 	result_adress=adress & IVP_VECFPU_MEM_MASK;
 	size+=(adress-result_adress)>>IVP_VECFPU_MEMSHIFT;
 	target_adress=(IVP_DOUBLE *)result_adress;
@@ -406,8 +406,8 @@ void IVP_Great_Matrix_Many_Zero::copy_matrix(IVP_Great_Matrix_Many_Zero *orig_ma
 
 
 void IVP_Great_Matrix_Many_Zero::align_matrix_values() {
-    intp adress,result_adress;
-    adress=(intp)matrix_values;
+    hk_intp adress,result_adress;
+    adress=(hk_intp)matrix_values;
     int maximal_shift=(IVP_VECFPU_SIZE-1)<<IVP_VECFPU_MEMSHIFT;
     result_adress=(adress+maximal_shift) & IVP_VECFPU_MEM_MASK;
     matrix_values=(IVP_DOUBLE*)result_adress;

--- a/ivp_intern/ivp_i_friction_hash.hxx
+++ b/ivp_intern/ivp_i_friction_hash.hxx
@@ -16,13 +16,13 @@ protected:
     
 public:
     void add_friction_info(IVP_Friction_Info_For_Core *fs_info){
-	add_elem( fs_info->l_friction_system , fs_info );
-	IVP_IF(1){
-	    IVP_Environment *env=fs_info->l_friction_system->l_environment;
-	    if( env->get_debug_manager()->check_fs ) {
-		IVP_ASSERT( find_friction_info(fs_info->l_friction_system) == fs_info );
-	    }
-	}
+		add_elem( fs_info->l_friction_system , fs_info );
+		IVP_IFDEBUG(1,
+			IVP_Environment *env=fs_info->l_friction_system->l_environment;
+			if( env->get_debug_manager()->check_fs ) {
+			IVP_ASSERT( find_friction_info(fs_info->l_friction_system) == fs_info );
+			}
+		)
     };
 
     IVP_Friction_Info_For_Core *remove_friction_info(IVP_Friction_Info_For_Core *fs_info){

--- a/ivp_intern/ivp_i_friction_hash.hxx
+++ b/ivp_intern/ivp_i_friction_hash.hxx
@@ -17,7 +17,7 @@ protected:
 public:
     void add_friction_info(IVP_Friction_Info_For_Core *fs_info){
 		add_elem( fs_info->l_friction_system , fs_info );
-		IVP_IFDEBUG(1,
+		IVP_IFDEBUG(IVP_TRUE,
 			IVP_Environment *env=fs_info->l_friction_system->l_environment;
 			if( env->get_debug_manager()->check_fs ) {
 			IVP_ASSERT( find_friction_info(fs_info->l_friction_system) == fs_info );

--- a/ivp_intern/ivp_impact.cxx
+++ b/ivp_intern/ivp_impact.cxx
@@ -1606,7 +1606,7 @@ IVP_BOOL IVP_Impact_System::test_loop_all_pairs()
 	    IVP_Contact_Point *my_fr = my_pair->fr_dists.element_at(k);
 	    if(my_fr->tmp_contact_info->coll_time_is_valid==IVP_TRUE) {
 	      IVP_IF(l_environment->get_debug_manager()->debug_imp_sys) {
-		ivp_message("did_not_test %zi\n",0x0000ffff&(intp)my_fr);
+		ivp_message("did_not_test %zi\n",0x0000ffff&(hk_intp)my_fr);
 	      }
 	    } else {
 		l_environment->get_statistic_manager()->impact_coll_checks++;
@@ -1821,7 +1821,7 @@ void IVP_Contact_Point::calc_coll_distance(){
 	    IVP_Core *core0,*core1;
 	    core0=get_synapse(0)->l_obj->friction_core;
 	    core1=get_synapse(1)->l_obj->friction_core;
-	    fprintf(fp,"  %zi %zi-%zi: ",0x0000ffff&(intp)this,0x0000ffff&(intp)core0,0x0000ffff&(intp)core1);
+	    fprintf(fp,"  %zi %zi-%zi: ",0x0000ffff&(hk_intp)this,0x0000ffff&(hk_intp)core0,0x0000ffff&(hk_intp)core1);
 	    fprintf(fp,"di %.4f  ",get_gap_length());
 	    IVP_DOUBLE debug_cs = closing_speed + info->impact.rescue_speed_addon*0.5f;
 	    fprintf(fp,"cs %.4f  ",debug_cs);
@@ -1829,7 +1829,7 @@ void IVP_Contact_Point::calc_coll_distance(){
 	}
 	IVP_IF(env->get_debug_manager()->debug_imp_sys) {
 	    ivp_message("tested_frdist %zi di %.4f cs %.4f dr %.4f\n",
-		0x0000ffff&(intp)this,
+		0x0000ffff&(hk_intp)this,
 		get_gap_length(),
 		closing_speed + info->impact.rescue_speed_addon*0.5f,
 		info->impact.distance_reached_in_time);

--- a/ivp_intern/ivp_impact.cxx
+++ b/ivp_intern/ivp_impact.cxx
@@ -241,9 +241,9 @@ IVP_Contact_Point *IVP_Mindist::try_to_generate_managed_friction(IVP_Friction_Sy
 #endif        
     friction_dist->calc_virtual_mass_of_mindist();
     
-    IVP_IF(obj0->get_environment()->get_debug_manager()->check_fs) {
-	affected_fs->test_hole_fr_system_data();
-    }
+    IVP_IFDEBUG(obj0->get_environment()->get_debug_manager()->check_fs,
+		affected_fs->test_hole_fr_system_data();
+	)
     
     IVP_Simulation_Unit *sim0,*sim1;
     sim0=core0->sim_unit_of_core;
@@ -645,9 +645,9 @@ void IVP_Impact_Solver::do_impact(IVP_Core *pushed_cores[2],IVP_BOOL allow_delay
     //IVP_DOUBLE relative_trans_speed_before;
     IVP_DOUBLE used_conservation;
 
-    IVP_IF(1) {
-	core[0]->environment->get_debug_manager()->all_time_impacts += 1.0f;
-    }
+    IVP_DEBUGCODE(
+		core[0]->environment->get_debug_manager()->all_time_impacts += 1.0f;
+	)
 
     used_conservation = 1.0f - (1.0f/(pushes_while_system*IVP_INV_HALF_CONSERVATION_STEPS+1.0f))
 	* (1.0f-percent_energy_conservation);
@@ -1443,17 +1443,17 @@ void IVP_Impact_System::init_and_solve_impact_system(IVP_Mindist *mindist, IVP_F
     add_pair_to_impact_system(start_pair);
     impact_system_check_start_pair(start_pair,start_fr_dist);
     
-    IVP_IF(1) {
+    IVP_DEBUGCODE(
         l_environment->get_debug_manager()->debug_imp_sys=IVP_FALSE;
-    }
+	)
     
-    IVP_IF(l_environment->get_debug_manager()->file_out_impacts) {
+    IVP_IFDEBUG(l_environment->get_debug_manager()->file_out_impacts,
         if(l_environment->get_current_time().get_time() > 10000.86f) {
-	    ivp_message("critical_imp_sys\n");
-	    l_environment->get_debug_manager()->debug_imp_sys=IVP_TRUE;
-	}
+			ivp_message("critical_imp_sys\n");
+			l_environment->get_debug_manager()->debug_imp_sys=IVP_TRUE;
+		}
         fprintf(l_environment->get_debug_manager()->out_deb_file,"starting_impact_system at time %f\n",l_environment->get_current_time().get_time());
-    }
+	)
 
     int impact_sys_counter = 0;
     while(test_loop_all_pairs()==IVP_TRUE)    {
@@ -1492,10 +1492,10 @@ void IVP_Impact_System::init_and_solve_impact_system(IVP_Mindist *mindist, IVP_F
     IVP_IF(1) {
 	associated_fs_system->debug_clean_tmp_info();
     }
-    IVP_IF(l_environment->get_debug_manager()->file_out_impacts) {
-	l_environment->get_debug_manager()->debug_imp_sys=IVP_FALSE;	
+    IVP_IFDEBUG(l_environment->get_debug_manager()->file_out_impacts,
+		l_environment->get_debug_manager()->debug_imp_sys=IVP_FALSE;	
         fprintf(l_environment->get_debug_manager()->out_deb_file,"\n");
-    }
+	)
 }
 
 void IVP_Impact_System::add_pair_to_impact_system(IVP_Friction_Core_Pair *new_pair)
@@ -1591,9 +1591,9 @@ IVP_BOOL IVP_Impact_System::test_loop_all_pairs()
     IVP_Friction_Core_Pair *associated_pair = NULL;
     IVP_DOUBLE smallest_distance =  ivp_mindist_settings.minimum_friction_dist;
     IVP_DOUBLE rescue_speed_addon=0.0f;
-    IVP_IF(l_environment->get_debug_manager()->file_out_impacts) {
+    IVP_IFDEBUG(l_environment->get_debug_manager()->file_out_impacts,
         fprintf(l_environment->get_debug_manager()->out_deb_file,"calc_new_coll_distances\n");
-    }
+	)
     for (int i = i_s_pairs.len()-1; i >= 0 ; i--){
 	IVP_Friction_Core_Pair *my_pair = i_s_pairs.element_at(i);
 	int unmov0,unmov1;
@@ -1605,12 +1605,12 @@ IVP_BOOL IVP_Impact_System::test_loop_all_pairs()
 	for (int k = my_pair->fr_dists.len()-1; k>=0; k--){
 	    IVP_Contact_Point *my_fr = my_pair->fr_dists.element_at(k);
 	    if(my_fr->tmp_contact_info->coll_time_is_valid==IVP_TRUE) {
-	      IVP_IF(l_environment->get_debug_manager()->debug_imp_sys) {
-		ivp_message("did_not_test %zi\n",0x0000ffff&(hk_intp)my_fr);
-	      }
+			IVP_IFDEBUG(l_environment->get_debug_manager()->debug_imp_sys,
+				ivp_message("did_not_test %zi\n",0x0000ffff&(hk_intp)my_fr);
+			)
 	    } else {
-		l_environment->get_statistic_manager()->impact_coll_checks++;
-		my_fr->calc_coll_distance();
+			l_environment->get_statistic_manager()->impact_coll_checks++;
+			my_fr->calc_coll_distance();
 	    }
 	    if(my_fr->tmp_contact_info->impact.distance_reached_in_time< smallest_distance ) {
 		rescue_speed_addon=my_fr->tmp_contact_info->impact.rescue_speed_addon;
@@ -1620,9 +1620,9 @@ IVP_BOOL IVP_Impact_System::test_loop_all_pairs()
 	    }
 	}
     }
-    IVP_IF(l_environment->get_debug_manager()->file_out_impacts) {
+    IVP_IFDEBUG(l_environment->get_debug_manager()->file_out_impacts,
         fprintf(l_environment->get_debug_manager()->out_deb_file,"\n");
-    }
+	)
     
     if(worst_impact_dist){
 	IVP_ASSERT(worst_impact_dist->tmp_contact_info->impact.distance_reached_in_time < ivp_mindist_settings.minimum_friction_dist);
@@ -1815,26 +1815,28 @@ void IVP_Contact_Point::calc_coll_distance(){
     info->impact.distance_reached_in_time = get_gap_length() - ( closing_speed + info->impact.rescue_speed_addon * 0.5f ) * env->get_delta_PSI_time();
     //rescue speed * 0.5f : at impact demand full rescue_speed; at testing, demand only half (to assure termination)
 
-    IVP_IF(1){
-	IVP_IF(env->get_debug_manager()->file_out_impacts) {
-	    FILE *fp=env->get_debug_manager()->out_deb_file;
-	    IVP_Core *core0,*core1;
-	    core0=get_synapse(0)->l_obj->friction_core;
-	    core1=get_synapse(1)->l_obj->friction_core;
-	    fprintf(fp,"  %zi %zi-%zi: ",0x0000ffff&(hk_intp)this,0x0000ffff&(hk_intp)core0,0x0000ffff&(hk_intp)core1);
-	    fprintf(fp,"di %.4f  ",get_gap_length());
-	    IVP_DOUBLE debug_cs = closing_speed + info->impact.rescue_speed_addon*0.5f;
-	    fprintf(fp,"cs %.4f  ",debug_cs);
-	    fprintf(fp,"dr %.4f  ",info->impact.distance_reached_in_time);
-	}
-	IVP_IF(env->get_debug_manager()->debug_imp_sys) {
-	    ivp_message("tested_frdist %zi di %.4f cs %.4f dr %.4f\n",
-		0x0000ffff&(hk_intp)this,
-		get_gap_length(),
-		closing_speed + info->impact.rescue_speed_addon*0.5f,
-		info->impact.distance_reached_in_time);
-	}
-    }
+    IVP_DEBUGCODE(
+		IVP_IFDEBUG(env->get_debug_manager()->file_out_impacts,
+			FILE *fp=env->get_debug_manager()->out_deb_file;
+			IVP_Core *core0,*core1;
+			core0=get_synapse(0)->l_obj->friction_core;
+			core1=get_synapse(1)->l_obj->friction_core;
+			fprintf(fp,"  %zi %zi-%zi: ",0x0000ffff&(hk_intp)this,0x0000ffff&(hk_intp)core0,0x0000ffff&(hk_intp)core1);
+			fprintf(fp,"di %.4f  ",get_gap_length());
+			IVP_DOUBLE debug_cs = closing_speed + info->impact.rescue_speed_addon*0.5f;
+			fprintf(fp,"cs %.4f  ",debug_cs);
+			fprintf(fp,"dr %.4f  ",info->impact.distance_reached_in_time);
+		)
+	
+		IVP_IFDEBUG(env->get_debug_manager()->debug_imp_sys,
+			ivp_message("tested_frdist %zi di %.4f cs %.4f dr %.4f\n",
+				0x0000ffff&(hk_intp)this,
+				get_gap_length(),
+				closing_speed + info->impact.rescue_speed_addon*0.5f,
+				info->impact.distance_reached_in_time
+			);
+		)
+	)
 };
 
 class IVP_Vector_of_Hull_Managers_256: public IVP_U_Vector<IVP_Hull_Manager_Base> {

--- a/ivp_intern/ivp_impact.cxx
+++ b/ivp_intern/ivp_impact.cxx
@@ -1818,9 +1818,8 @@ void IVP_Contact_Point::calc_coll_distance(){
     IVP_DEBUGCODE(
 		IVP_IFDEBUG(env->get_debug_manager()->file_out_impacts,
 			FILE *fp=env->get_debug_manager()->out_deb_file;
-			IVP_Core *core0,*core1;
-			core0=get_synapse(0)->l_obj->friction_core;
-			core1=get_synapse(1)->l_obj->friction_core;
+			IVP_Core *core0=get_synapse(0)->l_obj->friction_core;
+			IVP_Core *core1=get_synapse(1)->l_obj->friction_core;
 			fprintf(fp,"  %zi %zi-%zi: ",0x0000ffff&(hk_intp)this,0x0000ffff&(hk_intp)core0,0x0000ffff&(hk_intp)core1);
 			fprintf(fp,"di %.4f  ",get_gap_length());
 			IVP_DOUBLE debug_cs = closing_speed + info->impact.rescue_speed_addon*0.5f;

--- a/ivp_intern/ivp_physic_private.cxx
+++ b/ivp_intern/ivp_physic_private.cxx
@@ -538,7 +538,7 @@ void IVP_Core::freeze_simulation_core(){
 }
 
 void IVP_Core::debug_out_movement_vars() {
-    ivp_message("core_status %zi  trans %f %f %f  rot %f %f %f\n",(intp)this&0x0000ffff,speed.k[0],speed.k[1],speed.k[2],rot_speed.k[0],rot_speed.k[1],rot_speed.k[2]); 
+    ivp_message("core_status %zi  trans %f %f %f  rot %f %f %f\n",(hk_intp)this&0x0000ffff,speed.k[0],speed.k[1],speed.k[2],rot_speed.k[0],rot_speed.k[1],rot_speed.k[2]); 
 }
 
 void IVP_Core::debug_vec_movement_state() {
@@ -551,7 +551,7 @@ void IVP_Core::debug_vec_movement_state() {
 	int v_color;
 	ivp_start.set(my_core->get_position_PSI());	
 	ivp_pointer.set(0.0f,-7.0f,0.0f);
-	out_text=p_make_string("oob%zi_sp%.3f",(intp)one_object&0x0000ffff,one_object->speed.real_length());//,one_object->get_energy_on_test(&one_object->speed,&one_object->rot_speed));
+	out_text=p_make_string("oob%zi_sp%.3f",(hk_intp)one_object&0x0000ffff,one_object->speed.real_length());//,one_object->get_energy_on_test(&one_object->speed,&one_object->rot_speed));
 	if(my_core->movement_state==IVP_MT_CALM)	{
 	    //out_text=p_export_error("%lxo_calm%lx",(long)one_object&0x0000ffff,(long)fr_i&0x0000ffff);
 	    //sprintf(out_text,"%ldobj_calm%lx",counter,(long)one_object);

--- a/ivp_intern/ivp_physic_private.cxx
+++ b/ivp_intern/ivp_physic_private.cxx
@@ -580,9 +580,9 @@ void IVP_Core::debug_vec_movement_state() {
 
 IVP_Friction_System::IVP_Friction_System(IVP_Environment *env)
 {
-    IVP_IF(env->get_debug_manager()->check_fs) {
-	fprintf(env->get_debug_manager()->out_deb_file,"create_fs %f %p\n",env->get_current_time().get_time(),this);
-    }
+    IVP_IFDEBUG(env->get_debug_manager()->check_fs, 
+		fprintf(env->get_debug_manager()->out_deb_file,"create_fs %f %p\n",env->get_current_time().get_time(),this);
+	)
     //ivp_message("creating_new_fs %lx at time %f\n",(long)this,env->get_current_time());
     l_environment=env;
     next_friction_system = prev_friction_system = nullptr;
@@ -599,9 +599,9 @@ IVP_Friction_System::IVP_Friction_System(IVP_Environment *env)
 IVP_Friction_System::~IVP_Friction_System()
 {
     //ivp_message("deleting_of_fs %lx at time %f\n",(long)this,l_environment->get_current_time());
-    IVP_IF(l_environment->get_debug_manager()->check_fs) {
-	fprintf(l_environment->get_debug_manager()->out_deb_file,"delete_fs %f %p\n",l_environment->get_current_time().get_time(),this);
-    }
+    IVP_IFDEBUG(l_environment->get_debug_manager()->check_fs,
+		fprintf(l_environment->get_debug_manager()->out_deb_file,"delete_fs %f %p\n",l_environment->get_current_time().get_time(),this);
+	)
     // deleteing of real friction systems filled with information is not yet implemented (not trivial : unlink whole friction infos)
 
     //Assertion: when
@@ -658,9 +658,9 @@ IVP_BOOL IVP_Friction_System::dist_removed_update_pair_info(IVP_Contact_Point *o
 
 void IVP_Friction_System::remove_dist_from_system(IVP_Contact_Point *old_dist)
 {
-    IVP_IF(l_environment->get_debug_manager()->check_fs) {
-	fprintf(l_environment->get_debug_manager()->out_deb_file,"rem_dist_from_fs %f %p from %p\n",l_environment->get_current_time().get_time(),old_dist,this);
-    }
+    IVP_IFDEBUG(l_environment->get_debug_manager()->check_fs,
+		fprintf(l_environment->get_debug_manager()->out_deb_file,"rem_dist_from_fs %f %p from %p\n",l_environment->get_current_time().get_time(),old_dist,this);
+	)
 
     //manage list of all dists
     {
@@ -704,9 +704,9 @@ void IVP_Friction_System::dist_added_update_pair_info(IVP_Contact_Point *new_dis
 
 void IVP_Friction_System::add_dist_to_system(IVP_Contact_Point *new_dist)
 {
-    IVP_IF(l_environment->get_debug_manager()->check_fs) {
-	fprintf(l_environment->get_debug_manager()->out_deb_file,"add_dist_to_fs %f %p to %p\n",l_environment->get_current_time().get_time(),new_dist,this);
-    }
+    IVP_IFDEBUG(l_environment->get_debug_manager()->check_fs,
+		fprintf(l_environment->get_debug_manager()->out_deb_file,"add_dist_to_fs %f %p to %p\n",l_environment->get_current_time().get_time(),new_dist,this);
+	)
 
     new_dist->l_friction_system=this;
     //manage list of all dists
@@ -732,9 +732,9 @@ void IVP_Friction_System::add_dist_to_system(IVP_Contact_Point *new_dist)
 
 void IVP_Friction_System::add_core_to_system(IVP_Core *new_obj)
 {
-    IVP_IF(l_environment->get_debug_manager()->check_fs) {
-	fprintf(l_environment->get_debug_manager()->out_deb_file,"add_core_to_fs %f %p to %p\n",l_environment->get_current_time().get_time(),new_obj,this);
-    }
+    IVP_IFDEBUG(l_environment->get_debug_manager()->check_fs,
+		fprintf(l_environment->get_debug_manager()->out_deb_file,"add_core_to_fs %f %p to %p\n",l_environment->get_current_time().get_time(),new_obj,this);
+	)
 
     cores_of_friction_system.add(new_obj);
     if(!new_obj->physical_unmoveable) {
@@ -752,9 +752,9 @@ void IVP_Friction_System::add_core_to_system(IVP_Core *new_obj)
  
 void IVP_Friction_System::remove_core_from_system(IVP_Core *old_obj)
 {
-    IVP_IF(l_environment->get_debug_manager()->check_fs) {
-	fprintf(l_environment->get_debug_manager()->out_deb_file,"remove_core_from_fs %f %p from %p\n",l_environment->get_current_time().get_time(),old_obj,this);
-    }
+    IVP_IFDEBUG(l_environment->get_debug_manager()->check_fs,
+		fprintf(l_environment->get_debug_manager()->out_deb_file,"remove_core_from_fs %f %p from %p\n",l_environment->get_current_time().get_time(),old_obj,this);
+	)
 
     if(!old_obj->physical_unmoveable) {
         moveable_cores_of_friction_system.remove(old_obj);

--- a/ivp_physics/ivp_betterdebugmanager.cxx
+++ b/ivp_physics/ivp_betterdebugmanager.cxx
@@ -30,7 +30,7 @@ void IVP_BetterDebugmanager::disable_debug_output(IVP_DEBUG_CLASS class_id) {
 }
 
 
-IVP_BOOL IVP_BetterDebugmanager::is_debug_enabled(IVP_DEBUG_CLASS class_id) {
+IVP_BOOL IVP_BetterDebugmanager::is_debug_enabled(IVP_DEBUG_CLASS class_id) const {
 
     if (class_id >= IVP_DEBUG_MAX_N_CLASSES ) {
 	return(IVP_FALSE);
@@ -39,6 +39,12 @@ IVP_BOOL IVP_BetterDebugmanager::is_debug_enabled(IVP_DEBUG_CLASS class_id) {
 	return(IVP_FALSE);
     }
     return(IVP_TRUE);
+}
+
+
+IVP_BOOL IVP_BetterDebugmanager::is_debug_enabled(IVP_BOOL toggle) const {
+
+    return(toggle);
 }
 
 

--- a/ivp_physics/ivp_betterdebugmanager.hxx
+++ b/ivp_physics/ivp_betterdebugmanager.hxx
@@ -6,7 +6,9 @@
 #define _IVP_BETTERDEBUGMANAGER_INCLUDED
 
 #ifndef IVP_NO_DEBUGMANAGER
-#define IVP_IFDEBUG(dci, func)	if (ivp_debugmanager.is_debug_enabled(dci)) func
+// dimhotepus: Use func parameter
+#define IVP_IFDEBUG(dci, func)	if (ivp_debugmanager.is_debug_enabled(dci)) { func }
+// dimhotepus: Use func parameter
 #define IVP_DEBUGCODE(func) func
 #else
 #define IVP_IFDEBUG(a, b) if (0) {}
@@ -43,7 +45,8 @@ public:
     void     enable_debug_output(IVP_DEBUG_CLASS class_id);
     void     disable_debug_output(IVP_DEBUG_CLASS class_id);
 
-    IVP_BOOL is_debug_enabled(IVP_DEBUG_CLASS class_identifier);
+    IVP_BOOL is_debug_enabled(IVP_DEBUG_CLASS class_identifier) const;
+    IVP_BOOL is_debug_enabled(IVP_BOOL toggle) const;
     void     dprint(IVP_DEBUG_CLASS class_id, const char *formatstring, ...);
 
     // feel free to override this method with your customized

--- a/ivp_physics/ivp_betterdebugmanager.hxx
+++ b/ivp_physics/ivp_betterdebugmanager.hxx
@@ -5,8 +5,13 @@
 #ifndef _IVP_BETTERDEBUGMANAGER_INCLUDED
 #define _IVP_BETTERDEBUGMANAGER_INCLUDED
 
-
-#define IVP_IFDEBUG(dci)	if (ivp_debugmanager.is_debug_enabled(dci))
+#ifndef IVP_NO_DEBUGMANAGER
+#define IVP_IFDEBUG(dci, func)	if (ivp_debugmanager.is_debug_enabled(dci)) func
+#define IVP_DEBUGCODE(func) func
+#else
+#define IVP_IFDEBUG(a, b) if (0) {}
+#define IVP_DEBUGCODE(func)
+#endif
 
 
 // NOTE: The values from 0-1023 are reserved for internal

--- a/ivp_physics/ivp_physics.hxx
+++ b/ivp_physics/ivp_physics.hxx
@@ -21,6 +21,9 @@
 
 #if defined(LINUX)
 #	include <cstring>
+	#include <climits>
+	#define isnan std::isnan // cmath doesn't have this on linux >:(
+	#define _finite std::isfinite // windows specific function.
 #endif
 
 #ifndef _IVP_U_TYPES_INCLUDED

--- a/ivp_physics/ivp_physics.hxx
+++ b/ivp_physics/ivp_physics.hxx
@@ -21,9 +21,7 @@
 
 #if defined(LINUX)
 #	include <cstring>
-	#include <climits>
-	#define isnan std::isnan // cmath doesn't have this on linux >:(
-	#define _finite std::isfinite // windows specific function.
+#	include <climits>
 #endif
 
 #ifndef _IVP_U_TYPES_INCLUDED

--- a/ivp_physics/ivp_physics.hxx
+++ b/ivp_physics/ivp_physics.hxx
@@ -85,6 +85,10 @@
 #endif
 
 
+#ifndef _IVP_BETTERDEBUGMANAGER_INCLUDED
+#	include <ivp_betterdebugmanager.hxx>
+#endif
+
 #include <ivu_string.hxx>
 
 #define IVP_NO_MD_INTERPOLATION 

--- a/ivp_surface_manager/ivp_compact_grid.hxx
+++ b/ivp_surface_manager/ivp_compact_grid.hxx
@@ -52,7 +52,7 @@ public:
 
     IVP_FLOAT		radius;
 
-    intp			byte_size;
+    hk_intp			byte_size;
     
     IVP_FLOAT		inv_grid_size;
 
@@ -67,7 +67,7 @@ public:
      *  Description:    INTERNAL METHOD
      *****************************************************************************/
     const IVP_Compact_Grid_Element *get_grid_elements() {
-    	char *base = (char *)(((intp)this) + this->offset_grid_elements);
+    	char *base = (char *)(((hk_intp)this) + this->offset_grid_elements);
 	return((const IVP_Compact_Grid_Element *)base);
     }
 
@@ -76,7 +76,7 @@ public:
      *  Description:    INTERNAL METHOD
      *****************************************************************************/
     const IVP_Compact_Ledge *get_compact_ledge_at(int i) {
-    	char *base = (char *)(((intp)this) + this->offset_compact_ledge_array[i]);
+    	char *base = (char *)(((hk_intp)this) + this->offset_compact_ledge_array[i]);
 	return((const IVP_Compact_Ledge *)base);
     }
 

--- a/ivp_surface_manager/ivp_compact_surface.hxx
+++ b/ivp_surface_manager/ivp_compact_surface.hxx
@@ -52,7 +52,7 @@ public:
      *  Description:    INTERNAL METHOD
      *****************************************************************************/
     const IVP_Compact_Ledgetree_Node *get_compact_ledge_tree_root() const {
-	char *base = (char *)(((intp)this) + this->offset_ledgetree_root);
+	char *base = (char *)(((hk_intp)this) + this->offset_ledgetree_root);
 	return((const IVP_Compact_Ledgetree_Node *)base);
     }
 

--- a/ivp_surface_manager/ivp_gridbuild_array.cxx
+++ b/ivp_surface_manager/ivp_gridbuild_array.cxx
@@ -58,7 +58,7 @@ IVP_GridBuilder_Array::IVP_GridBuilder_Array(IVP_U_Memory *mm_, const IVP_Templa
 	    dest->k[ gp->height_maps_to ]      = float(source[0] * dz);
 	    source++;
 	    dest++;
-		IVP_ASSERT( ((intp)dest & 15) == 0 );
+		IVP_ASSERT( ((hk_intp)dest & 15) == 0 );
 	    y += dy;
 	}
 	x += dx;
@@ -74,7 +74,7 @@ int IVP_GridBuilder_Array::install_grid_point(int grid_point_index){
     compact_poly_point_buffer[ index ] = height_points[grid_point_index];
 	IVP_IF(1) {
 		IVP_Compact_Poly_Point *cpp=&compact_poly_point_buffer[ index ];
-        intp adress=(intp)cpp;
+        hk_intp adress=(hk_intp)cpp;
 		IVP_ASSERT( (adress & 15)==0 );
 	}
     return index;
@@ -84,7 +84,7 @@ int IVP_GridBuilder_Array::install_point(const IVP_U_Float_Point *point){
     int index = n_compact_poly_points_used++;
 	IVP_IF(1) {
 		IVP_Compact_Poly_Point *cpp=&compact_poly_point_buffer[ index ];
-        intp adress=(intp)cpp;
+        hk_intp adress=(hk_intp)cpp;
 		IVP_ASSERT( (adress & 15)==0 );
 	}
     compact_poly_point_buffer[ index ].set(point);
@@ -181,7 +181,7 @@ IVP_Compact_Ledge *IVP_GridBuilder_Array::convert_convex_triangle_to_compact_led
     int mem_size = 	sizeof(IVP_Compact_Ledge) +	num_triangles * sizeof(IVP_Compact_Triangle);
 
     this->c_ledge = (IVP_Compact_Ledge *)mm->get_memc( mem_size);
-    IVP_ASSERT( (intp(this->c_ledge) & 15) == 0);	// make sure it is aligned
+    IVP_ASSERT( (hk_intp(this->c_ledge) & 15) == 0);	// make sure it is aligned
 
     { // set point arrays
 	// search the minimum point index and install points
@@ -235,7 +235,7 @@ IVP_Compact_Ledge *IVP_GridBuilder_Array::convert_convex_square_to_compact_ledge
     int mem_size = 	sizeof(IVP_Compact_Ledge) +	num_triangles * sizeof(IVP_Compact_Triangle);
 
     this->c_ledge = (IVP_Compact_Ledge *)mm->get_memc( mem_size);
-    IVP_ASSERT( (intp(this->c_ledge) & 15) == 0);	// make sure it is aligned
+    IVP_ASSERT( (hk_intp(this->c_ledge) & 15) == 0);	// make sure it is aligned
 
     { // set point arrays
 	// search the minimum point index and install points
@@ -320,7 +320,7 @@ IVP_Compact_Ledge *IVP_GridBuilder_Array::convert_convex_stripe_to_compact_ledge
     int mem_size = 	sizeof(IVP_Compact_Ledge) +	num_triangles * sizeof(IVP_Compact_Triangle);
 
     this->c_ledge = (IVP_Compact_Ledge *)mm->get_memc( mem_size);
-    IVP_ASSERT ( (intp(c_ledge) & 15) == 0);
+    IVP_ASSERT ( (hk_intp(c_ledge) & 15) == 0);
 
 
 
@@ -732,7 +732,7 @@ void IVP_GridBuilder_Array::convert_array_to_compact_ledges( const IVP_Template_
 /* merge everything into the final compact grid thing */
 IVP_Compact_Grid *IVP_GridBuilder_Array::compile_ledges_into_compact_grid(const IVP_Template_Compact_Grid *gp,IVP_U_Vector<IVP_Compact_Ledge> *ledges){
 	IVP_Compact_Grid *cg = NULL;
-	intp buffer_size = offsetof(IVP_Compact_Grid, offset_compact_ledge_array);	// size for base compact ledge
+	hk_intp buffer_size = offsetof(IVP_Compact_Grid, offset_compact_ledge_array);	// size for base compact ledge
 
 	buffer_size += ledges->len() * sizeof(int); // add buffersize for ledge index array
 	buffer_size += (n_rows-1) * (n_cols-1) * sizeof(IVP_Compact_Grid_Element);	 //the grid referencing ledge index array
@@ -829,7 +829,7 @@ IVP_Compact_Grid *IVP_GridBuilder_Array::compile_ledges_into_compact_grid(const 
 		}
 
 		// and the ledges
-		dest = (char *)((intp(dest)+0xf) & ~0xf);     	// align destination
+		dest = (char *)((hk_intp(dest)+0xf) & ~0xf);     	// align destination
 		for (int ledge_index = 0; ledge_index < ledges->len(); ledge_index++){
 			IVP_Compact_Ledge *cl;
 			cl = ledges->element_at(ledge_index);

--- a/ivp_utility/ivu_hash.cxx
+++ b/ivp_utility/ivu_hash.cxx
@@ -201,8 +201,8 @@ void IVP_Hash::remove(const char *key){
 int IVP_U_String_Hash::hash_index(const char *key)const {
 	unsigned int c;		
 	unsigned int index = 0xffffffffL;
-	intp i;
-	intp key_size = strlen(key);
+	hk_intp i;
+	hk_intp key_size = strlen(key);
 	for (i=key_size-1;i>=0;i--){
 	    c = *((unsigned char *)(key++));
 	    index = IVP_Hash_crctab[((int) index ^ c) & 0xff] ^ (index >> 8);
@@ -247,7 +247,7 @@ void *IVP_U_String_Hash::find(const char *key)const{
 
 void IVP_U_String_Hash::add(const char *key, void *val){
     int i = hash_index(key);
-    intp keysize = strlen(key);
+    hk_intp keysize = strlen(key);
     IVP_Hash_Elem *el = (IVP_Hash_Elem *)p_malloc(sizeof(IVP_Hash_Elem) + keysize);
     memcpy(el->key,key,keysize+1);
     el->next = elems[i];

--- a/ivp_utility/ivu_memory.cxx
+++ b/ivp_utility/ivu_memory.cxx
@@ -27,12 +27,12 @@ void ivp_memory_check(void *a) {
   //    }
 	    //int fp;
 	    //fp=sceOpen("host0:/ipion_out/ipion.txt",SCE_CREAT);
-		uintp address = (uintp)a;
+		hk_uintp address = (hk_uintp)a;
 		IVP_Time now_time = ivp_global_env->get_current_time();
 		IVP_DOUBLE tt = now_time.get_time();
 		if (tt > 11.98) {
 		    fprintf(stderr, "trying to free %p time %f\n", a, tt);
-		    if (a == (void *)(uintp)0x30ca50){
+		    if (a == (void *)(hk_uintp)0x30ca50){
 		    	fprintf(stderr, "Crashing soon\n");
 		    }
 
@@ -143,7 +143,7 @@ void *ivp_malloc_aligned(size_t size, unsigned short alignment) {
     if (data) {
         data->magic_number = IVP_MEMORY_MAGIC;
 
-        void *ret = (void *)((((uintp)data) + alignment + sizeof(IVP_Aligned_Memory) - 1) & (-static_cast<intp>(alignment)));
+        void *ret = (void *)((((hk_uintp)data) + alignment + sizeof(IVP_Aligned_Memory) - 1) & (-static_cast<hk_intp>(alignment)));
         ((void **)ret)[-1] = (void *)data;
         return ret;
     }
@@ -160,7 +160,7 @@ void* IVP_CDECL ivp_calloc_aligned(size_t size, unsigned short alignment) {
         memset(data, 0, size);
         data->magic_number = IVP_MEMORY_MAGIC;
 
-        void *ret = (void *)((((uintp)data) + alignment + sizeof(IVP_Aligned_Memory) - 1) & (-static_cast<intp>(alignment)));
+        void *ret = (void *)((((hk_uintp)data) + alignment + sizeof(IVP_Aligned_Memory) - 1) & (-static_cast<hk_intp>(alignment)));
         ((void **)ret)[-1] = (void *)data;
         return ret;
     }

--- a/ivp_utility/ivu_memory.hxx
+++ b/ivp_utility/ivu_memory.hxx
@@ -83,7 +83,7 @@ void IVP_U_Memory::end_memory_transaction()
 
 //warning: dependency with function neuer_sp_block
 inline void *IVP_U_Memory::align_to_next_adress(void *p) {
-    uintp address = (uintp)p;
+    hk_uintp address = (hk_uintp)p;
     address += IVU_MEM_ALIGN-1;
     address = address & IVU_MEM_MASK;
     return (void*)address;
@@ -109,7 +109,7 @@ inline void	*IVP_U_Memory::get_mem(size_t groesse)
 		return this->neuer_sp_block(groesse);
 	} else {
 		speicherbeginn = p;
-		IVP_IF( ((intp)op > 0x780000 ) && ((intp)op < 0x792f48)) {
+		IVP_IF( ((hk_intp)op > 0x780000 ) && ((hk_intp)op < 0x792f48)) {
 			op++;
 			op--;
 		}

--- a/ivp_utility/ivu_set.hxx
+++ b/ivp_utility/ivu_set.hxx
@@ -38,7 +38,7 @@ class IVP_U_Set: public IVP_VHash {
   //friend class IVP_U_Set_Enumerator;
 protected:
     IVP_BOOL compare(const void *elem0, const void *elem1) const override { return (elem0 == elem1)?IVP_TRUE:IVP_FALSE; }
-    int      elem_to_index(T *elem){ return fast_hash_index((intp) elem); }
+    int      elem_to_index(T *elem){ return fast_hash_index((hk_intp) elem); }
 public:
   void add_element(T *elem){
       IVP_VHash::add_elem(elem, elem_to_index(elem));

--- a/ivp_utility/ivu_string.cxx
+++ b/ivp_utility/ivu_string.cxx
@@ -170,7 +170,7 @@ int P_String::string_cmp(const char *str,const char *search,IVP_BOOL upper_case)
 
 char *gbs_add_path(char *path,char *name)
 	{
-	intp i,len,found;
+	hk_intp i,len,found;
 	char *erg;
 	if (!name) return name;
 	if (!path) {

--- a/ivp_utility/ivu_types.hxx
+++ b/ivp_utility/ivu_types.hxx
@@ -193,8 +193,8 @@ using uchar = unsigned char; // feel free to remove these three typedefs
 using ushort = unsigned short;
 using uint = unsigned int;
 
-using intp = ptrdiff_t;
-using uintp = size_t;
+using hk_intp = ptrdiff_t;
+using hk_uintp = size_t;
 
 using IVP_ERROR_STRING = const char *;
 constexpr inline std::nullptr_t IVP_NO_ERROR{nullptr};
@@ -317,7 +317,7 @@ IVP_FLOAT ivp_rand();		// returns [0 .. 1]
 #	endif
 #	define IVP_IF_PREFETCH_ENABLED(x) if(x)
 #	include <xmmintrin.h>
-#	define IVP_PREFETCH( pntr, offset) _mm_prefetch( intp(offset) + (char *)pntr, _MM_HINT_T1)
+#	define IVP_PREFETCH( pntr, offset) _mm_prefetch( hk_intp(offset) + (char *)pntr, _MM_HINT_T1)
 #   endif
 
 

--- a/ivp_utility/ivu_vhash.cxx
+++ b/ivp_utility/ivu_vhash.cxx
@@ -277,7 +277,7 @@ void IVP_VHash::print()const{
     int i;
     ivp_message("%i:",len());
     for (i = 0; i<= size_mm;i++){
-	ivp_message (" %i:%X:%X  ", elems[i].hash_index & size_mm, (int)(intp)elems[i].elem, elems[i].hash_index);
+	ivp_message (" %i:%X:%X  ", elems[i].hash_index & size_mm, (int)(hk_intp)elems[i].elem, elems[i].hash_index);
     }
     ivp_message("\n");
 }
@@ -571,7 +571,7 @@ void IVP_VHash_Store::print(){
     int i;
     ivp_message("%i:",size);
     for (i = 0; i< size;i++){
-	ivp_message (" %i:%X:%X:%X  ", elems_store[i].hash_index & size_mm, (int)(intp)elems_store[i].key_elem, (int)(intp)elems_store[i].elem, elems_store[i].hash_index);
+	ivp_message (" %i:%X:%X:%X  ", elems_store[i].hash_index & size_mm, (int)(hk_intp)elems_store[i].key_elem, (int)(hk_intp)elems_store[i].elem, elems_store[i].hash_index);
     }
     ivp_message("\n");
 }

--- a/ivp_utility/ivu_vhash.hxx
+++ b/ivp_utility/ivu_vhash.hxx
@@ -40,8 +40,8 @@ protected:
     IVP_VHash(IVP_VHash_Elem *static_elems, int size);// assert(size = 2**x)
     virtual IVP_BOOL compare(const void *elem0, const void *elem1)const = 0;  // return TRUE if equal
 public:
-    static inline int hash_index(const char *data, intp size);            // useable index calculation, result is [0,0xfffffff]
-    static inline int fast_hash_index(intp key);       // useable index calculation when size == 4 , result is [0,0xfffffff]
+    static inline int hash_index(const char *data, hk_intp size);            // useable index calculation, result is [0,0xfffffff]
+    static inline int fast_hash_index(hk_intp key);       // useable index calculation when size == 4 , result is [0,0xfffffff]
 
     // touches element
     void add_elem(const void *elem, int hash_index);
@@ -76,10 +76,10 @@ public:
 
 
 // basic function for calculating the hash_index
-inline int IVP_VHash::hash_index(const char *key, intp key_size){
+inline int IVP_VHash::hash_index(const char *key, hk_intp key_size){
 	unsigned int c;		
 	unsigned int index = 0xffffffffL; //-V112
-	for (intp i=key_size-1;i>=0;i--){
+	for (hk_intp i=key_size-1;i>=0;i--){
 	    c = *((const unsigned char *)(key++));
 	    index = IVP_Hash_crctab[((int) index ^ c) & 0xff] ^ (index >> 8);
 	}
@@ -87,8 +87,8 @@ inline int IVP_VHash::hash_index(const char *key, intp key_size){
 };
 
 // basic function for calculating the hash_index of key is a long long
-constexpr int keyBits = sizeof(intp) * 4;
-inline int IVP_VHash::fast_hash_index(intp key) {
+constexpr int keyBits = sizeof(hk_intp) * 4;
+inline int IVP_VHash::fast_hash_index(hk_intp key) {
   int index = static_cast<int>(((key * 1001) >> keyBits) + key * 75); //-V112
   return index | IVP_VHASH_TOUCH_BIT;  // set touch bit
 }

--- a/ivp_utility/ivu_vhash.hxx
+++ b/ivp_utility/ivu_vhash.hxx
@@ -86,9 +86,9 @@ inline int IVP_VHash::hash_index(const char *key, hk_intp key_size){
 	return index | IVP_VHASH_TOUCH_BIT;	// set touch bit
 };
 
-// basic function for calculating the hash_index of key is a long long
-constexpr int keyBits = sizeof(hk_intp) * 4;
+// basic function for calculating the hash_index of key is a hk_intp
 inline int IVP_VHash::fast_hash_index(hk_intp key) {
+  constexpr int keyBits = sizeof(key) * 4;
   int index = static_cast<int>(((key * 1001) >> keyBits) + key * 75); //-V112
   return index | IVP_VHASH_TOUCH_BIT;  // set touch bit
 }

--- a/ivp_utility/ivu_vhash.hxx
+++ b/ivp_utility/ivu_vhash.hxx
@@ -41,8 +41,7 @@ protected:
     virtual IVP_BOOL compare(const void *elem0, const void *elem1)const = 0;  // return TRUE if equal
 public:
     static inline int hash_index(const char *data, intp size);            // useable index calculation, result is [0,0xfffffff]
-    static inline int fast_hash_index(int key);       // useable index calculation when size == 4 , result is [0,0xfffffff]
-    static inline int fast_hash_index(long long key);       // useable index calculation when size == 4 , result is [0,0xfffffff]
+    static inline int fast_hash_index(intp key);       // useable index calculation when size == 4 , result is [0,0xfffffff]
 
     // touches element
     void add_elem(const void *elem, int hash_index);
@@ -81,22 +80,16 @@ inline int IVP_VHash::hash_index(const char *key, intp key_size){
 	unsigned int c;		
 	unsigned int index = 0xffffffffL; //-V112
 	for (intp i=key_size-1;i>=0;i--){
-	for (i=key_size-1;i>=0;i--){
 	    c = *((const unsigned char *)(key++));
 	    index = IVP_Hash_crctab[((int) index ^ c) & 0xff] ^ (index >> 8);
 	}
 	return index | IVP_VHASH_TOUCH_BIT;	// set touch bit
-    };
-
-// basic function for calculating the hash_index of key is a long
-inline int IVP_VHash::fast_hash_index(int key){
-  int index =  ((key * 1001)>>16) + key * 75;
-  return index | IVP_VHASH_TOUCH_BIT;	// set touch bit
-}
+};
 
 // basic function for calculating the hash_index of key is a long long
-inline int IVP_VHash::fast_hash_index(long long key) {
-  int index = static_cast<int>(((key * 1001) >> 32) + key * 75); //-V112
+constexpr int keyBits = sizeof(intp) * 4;
+inline int IVP_VHash::fast_hash_index(intp key) {
+  int index = static_cast<int>(((key * 1001) >> keyBits) + key * 75); //-V112
   return index | IVP_VHASH_TOUCH_BIT;  // set touch bit
 }
 


### PR DESCRIPTION
While trying to include IVP in my project(https://github.com/RaphaelIT7/gmod-holylib) I encountered a few things which caused issues on Linux or when IVP was combined with the SourceSDK.

What I changed:
[+] Added `IVP_NO_PERFORMANCE_TIMER` define when the performance timer is not wanted
[+] Added `IVP_NO_DEBUGMANAGER` define when the debug manager is not wanted
\- Also changed `IVP_IFDEBUG` and added `IVP_DEBUGCODE` for it's implementation.
[+] Added missing `isnan` & `_finite` definitions for Linux into `ivp_physics.hxx`
[#] Improved Linux support
\- added ifdef checks for windows includes & directX functions
[#] Changed `IVP_VHash::hash_index`
\- Fixed the recently added compile error/the two if statements
\- Merged both versions of it into a single one
[#] renamed `intp` to `hk_intp` (same with `uintp`)
\- Solved compile issues when combined with the sourcesdk where `intp` was already defined/different.
[#] Changed some `asserts` to `HK_ASSERT`
\- assert wasn't usable everywhere while `HK_ASSERT` is.
[#] Fixed a infinite loop on linux
\- `hk_Memory::memset` and `hk_Memory::memcpy` would call themself recursively until it crashed.
[#] Added `get_controller_name` to all controllers for debugging.
\- previously they would show as `sys:unknown` which isn't useful at all.
[#] Changed all `IVP_IF` to `IVP_IFDEBUG` or `IVP_DEBUGCODE` if they used the debug manager.
\- This solved some crashes when the debug manager was previously disabled.
[-] Removed `IVP_Friction_System::sum_energy_destroyed` variable since its fully unused.