### PR TITLE
ivp_physics: fix ragdoll jitter due to wrong value

### DIFF
--- a/havana/havok/hk_physics/constraint/ragdoll/ragdoll_constraint.cpp
+++ b/havana/havok/hk_physics/constraint/ragdoll/ragdoll_constraint.cpp
@@ -273,7 +273,7 @@ int hk_Ragdoll_Constraint::setup_and_step_constraint(hk_PSI_Info &pi, void *mem,
 
     hk_Vector3 delta_dist_3;
     delta_dist_3.set_mul(tau_factor * m_tau * pi.get_inv_delta_time(), dir);
-    delta_dist_3.add_mul(-0.0f * m_strength * strength_factor,
+    delta_dist_3.add_mul(-1.0f * m_strength * strength_factor,
                          *(const hk_Vector3 *)approaching_velocity);
 
     hk_Fixed_Dense_Matrix<3> &mass_matrix =


### PR DESCRIPTION
Made & Found by @ZehMatt <3
Matches all other occurences of `delta_dist_3.add_mul` now

"The `-0.0f` silently killed velocity damping on the first iteration of each PSI and let ragdolls re-accumulate oscillating velocity -> wobble/jitter"